### PR TITLE
fix(vmix): account for start time when seeking an input

### DIFF
--- a/packages/timeline-state-resolver/src/devices/vmix.ts
+++ b/packages/timeline-state-resolver/src/devices/vmix.ts
@@ -381,13 +381,16 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 					case MappingVMixType.Input:
 						if (tlObject.content.type === TimelineContentTypeVMix.INPUT) {
 							const vmixTlMedia = tlObject as any as TimelineObjVMixInput
+							const startTime = tlObject.instance.originalStart ?? tlObject.instance.start
+							const delta = state.time - startTime
+							const position = typeof vmixTlMedia.content.seek === 'number' ? vmixTlMedia.content.seek + delta : delta
 							deviceState.reportedState.inputs = this.modifyInput(
 								deviceState,
 								{
 									type: vmixTlMedia.content.inputType,
 									playing: vmixTlMedia.content.playing,
 									loop: vmixTlMedia.content.loop,
-									position: vmixTlMedia.content.seek,
+									position,
 									transform: vmixTlMedia.content.transform,
 									overlays: vmixTlMedia.content.overlays,
 								},


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Say that a video was supposed to have begun playing 5 seconds ago. Before this fix, TSR wouldn't account for that and would always start playing the media at timecode zero.

* **What is the new behavior (if this is a feature change)?**

Now, TSR accounts for the start time of the instance when seeking a media input. If a media file was supposed to have started playing 5 seconds ago, TSR will now make VMix seek to 5 seconds into that media file when playback begins.

* **Other information**:

A new test has been added for this case.
