### PR TITLE
feat(Hyperdeck): add support for play and basic goto commands

### DIFF
--- a/packages/timeline-state-resolver-types/src/hyperdeck.ts
+++ b/packages/timeline-state-resolver-types/src/hyperdeck.ts
@@ -82,8 +82,16 @@ export interface TimelineObjHyperdeckTransport extends TimelineObjHyperdeck {
 		deviceType: DeviceType.HYPERDECK
 		type: TimelineContentTypeHyperdeck.TRANSPORT
 
-		/** The status of the hyperdeck. To start a recording, set to TransportStatus.RECORD */
+		/** The status of the hyperdeck. To start a recording, set to TransportStatus.RECORD. To start playback, set to TransportStatus.PLAY. */
 		status: TransportStatus
+		/** How fast to play the currently-playing clip [-5000 - 5000]. Default 1x speed is 100. 0 is stopped. Negative values are rewind. Values above 100 are fast-forward. */
+		speed: number
+		/** Whether or not to loop the currently-playing clip */
+		loop: boolean
+		/** Wheter or not to stop playback when the currently-playing clip is finished */
+		singleClip: boolean
+		/** The numeric ID of the clip to play. null = no clip */
+		clipId: number | null
 		/** The filename to record to */
 		recordFilename?: string
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

The `play` and `goto` commands of the Hyperdeck protocol are not supported.

* **What is the new behavior (if this is a feature change)?**

`play` is fully supported. `goto` has basic support for selecting a clip by ID. Other aspects of `goto` have not been implemented.

* **Other information**:

Tests have been added and the functionality has been tested via quickTSR over a remote connection to a Hyperdeck unit. Here are the input files I used: https://gist.github.com/alvancamp/320d1dc7c4387bb031acf8e7e0a1edc8
