### PR TITLE
Suppress connection warnings for UDP OSC devices

### DIFF
--- a/packages/timeline-state-resolver/src/devices/osc.ts
+++ b/packages/timeline-state-resolver/src/devices/osc.ts
@@ -111,6 +111,10 @@ export class OSCMessageDevice extends DeviceWithState<OSCDeviceState, DeviceOpti
 				metadata: true,
 			})
 			this._oscClient.open()
+
+			// UDP has no concept of being connected or not, so set status to
+			// 'connected' to suppress connection-related warnings.
+			this._oscClientStatus = 'connected'
 		}
 
 		return Promise.resolve(true) // This device doesn't have any initialization procedure


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
UDP OSC devices always have a 'disconnected' status which can cause warnings to be displayed in various consumers of TSR.


* **What is the new behavior (if this is a feature change)?**
UDP OSC devices are now always assumed to be connected, to suppress these warnings.


* **Other information**:
N/A