### PR TITLE
feat(vizMSE): include request body when Viz MSE client error caught

### DIFF
--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -765,7 +765,15 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 				errorString += '\n' + error.stack
 			}
 			if (e instanceof HTTPClientError || e instanceof HTTPServerError) {
-				errorString += '\n\n' + (e.body ?? '[No request body present]')
+				errorString +=
+					'\n\nPath: ' +
+					e.path +
+					'\n\n' +
+					(e.body ?? '[No request body present]') +
+					'\n\nStatus: ' +
+					e.status +
+					'\nResponse:\n' +
+					e.response
 			}
 			this.emit('commandError', new Error(errorString), cwc)
 		}

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -38,6 +38,7 @@ import * as net from 'net'
 import { ExpectedPlayoutItem } from '../expectedPlayoutItems'
 import * as request from 'request'
 import { startTrace, endTrace, deferAsync } from '../lib'
+import { HTTPClientError, HTTPServerError } from '@tv2media/v-connection/dist/msehttp'
 
 /** The ideal time to prepare elements before going on air */
 const IDEAL_PREPARE_TIME = 1000
@@ -761,7 +762,10 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 			const error = e as Error
 			let errorString = error && error.message ? error.message : error.toString()
 			if (error?.stack) {
-				errorString += error.stack
+				errorString += '\n' + error.stack
+			}
+			if (e instanceof HTTPClientError || e instanceof HTTPServerError) {
+				errorString += '\n\n' + (e.body ?? '[No request body present]')
 			}
 			this.emit('commandError', new Error(errorString), cwc)
 		}

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -766,14 +766,11 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 			}
 			if (e instanceof HTTPClientError || e instanceof HTTPServerError) {
 				errorString +=
-					'\n\nPath: ' +
-					e.path +
+					`\n\nPath: ${e.path}` +
 					'\n\n' +
 					(e.body ?? '[No request body present]') +
-					'\n\nStatus: ' +
-					e.status +
-					'\nResponse:\n' +
-					e.response
+					`\n\nStatus: ${e.status}` +
+					`\nResponse:\n ${e.response}`
 			}
 			this.emit('commandError', new Error(errorString), cwc)
 		}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

The Viz MSE request body is not included in the error message forwarded to the consuming library

* **What is the new behavior (if this is a feature change)?**

The Viz MSE request body should now be included in the emitted commandError.

* **Other information**:
