### PR TITLE
fix: stabilize timeline object callbacks by preferring originalStart in the callBackId

### DIFF
--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -104,7 +104,7 @@
 		"p-timeout": "^3.2.0",
 		"request": "^2.88.0",
 		"sprintf-js": "^1.1.2",
-		"superfly-timeline": "^8.2.7",
+		"superfly-timeline": "^8.2.8",
 		"threadedclass": "^1.0.2",
 		"timeline-state-resolver-types": "7.3.0-release44.0",
 		"tslib": "^2.3.1",

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -1123,11 +1123,9 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 	}
 
 	private _diffStateForCallbacks(activeObjects: TimelineCallbacks, tlTime: number) {
-		const time = this.getCurrentTime()
-
 		// Clear callbacks scheduled after the current tlState
 		for (const [callbackId, o] of Object.entries(this._sentCallbacks)) {
-			if (o.time >= time) {
+			if (o.time >= tlTime) {
 				delete this._sentCallbacks[callbackId]
 			}
 		}

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -1003,7 +1003,7 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 							instance.id +
 							instance.content.callBack +
 							instance.content.callBackStopped +
-							// instance.instance.start +
+							(instance.instance.originalStart ?? instance.instance.start) +
 							JSON.stringify(instance.content.callBackData)
 						activeObjects[callBackId] = {
 							time: instance.instance.start || 0,

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -1003,7 +1003,7 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 							instance.id +
 							instance.content.callBack +
 							instance.content.callBackStopped +
-							instance.instance.start +
+							// instance.instance.start +
 							JSON.stringify(instance.content.callBackData)
 						activeObjects[callBackId] = {
 							time: instance.instance.start || 0,
@@ -1023,7 +1023,7 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 				tlState.time,
 				undefined,
 				(sentCallbacksNew) => {
-					this._diffStateForCallbacks(sentCallbacksNew)
+					this._diffStateForCallbacks(sentCallbacksNew, tlState.time)
 				},
 				activeObjects
 			)
@@ -1122,7 +1122,7 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 		)
 	}
 
-	private _diffStateForCallbacks(activeObjects: TimelineCallbacks) {
+	private _diffStateForCallbacks(activeObjects: TimelineCallbacks, tlTime: number) {
 		const sentCallbacks: TimelineCallbacks = this._sentCallbacks
 		const time = this.getCurrentTime()
 
@@ -1136,6 +1136,7 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 		_.each(activeObjects, (cb, callBackId) => {
 			if (cb.callBack && cb.startTime) {
 				if (!sentCallbacks[callBackId]) {
+					// console.log(`Sending start: ${cb.id}, time: ${cb.startTime}, callBackId: ${callBackId}`)
 					// Object has started playing
 					this._queueCallback(true, {
 						type: 'start',
@@ -1153,9 +1154,14 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 		_.each(sentCallbacks, (cb, callBackId: string) => {
 			if (cb.callBackStopped && !activeObjects[callBackId]) {
 				// Object has stopped playing
+				// console.log(
+				// 	`Sending stop: ${cb.id}, time: ${tlTime}, diff: ${
+				// 		tlTime - (cb.expectedEndTime ?? tlTime)
+				// 	}, callBackId: ${callBackId}`
+				// )
 				this._queueCallback(false, {
 					type: 'stop',
-					time: time,
+					time: tlTime,
 					instanceId: cb.id,
 					callBack: cb.callBackStopped,
 					callBackData: cb.callBackData,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7920,10 +7920,10 @@ strtok3@^6.2.4:
     "@tokenizer/token" "^0.3.0"
     peek-readable "^4.1.0"
 
-superfly-timeline@^8.2.7:
-  version "8.2.7"
-  resolved "https://registry.yarnpkg.com/superfly-timeline/-/superfly-timeline-8.2.7.tgz#ddd49c64ddecf8464b6dfa98c3f7fbff799f9a44"
-  integrity sha512-CtI7+6hrrURjGlQ7ZQkVv0CtNkFTSM94XAPipiXH49MjMW7eq+C6Q5JsyOyMz2blMTVdU4ZdSy/wUuOqpgm/0g==
+superfly-timeline@^8.2.8:
+  version "8.2.8"
+  resolved "https://registry.yarnpkg.com/superfly-timeline/-/superfly-timeline-8.2.8.tgz#4f0df61494a0c5a7563c3745d066439d760f8a03"
+  integrity sha512-J9WXNHdyKGby1vp52Uv6BfEevXjBFPi01XyH6ts/mWcS56YdCftc1rmGoekLiIG5TBZ++XgtJdO1vwvCPfBaEQ==
   dependencies:
     tslib "^2.3.1"
     underscore "^1.13.2"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The callBackId can sometimes be a unstable, resulting in multiple callbacks where there should only be one.

* **What is the new behavior (if this is a feature change)?**

The callBackId uses originalStart falling back to start. Also, timeline state time is forwarded into `_diffStateForCallbacks`, instead of `getCurrentTime()`, since they can possibly be different.

* **Other information**:
