### PR TITLE
Feature: timeline datastore

### DIFF
--- a/packages/timeline-state-resolver-types/src/abstract.ts
+++ b/packages/timeline-state-resolver-types/src/abstract.ts
@@ -1,4 +1,4 @@
-import { TSRTimelineObjBase, DeviceType, Mapping } from '.'
+import { TSRTimelineObjBase, DeviceType, Mapping, TimelineDatastoreReferencesContent } from '.'
 
 export interface MappingAbstract extends Mapping {
 	device: DeviceType.ABSTRACT
@@ -11,5 +11,5 @@ export interface TSRTimelineObjAbstract extends TSRTimelineObjBase {
 	content: {
 		deviceType: DeviceType.ABSTRACT
 		[key: string]: any
-	}
+	} & TimelineDatastoreReferencesContent
 }

--- a/packages/timeline-state-resolver-types/src/atem.ts
+++ b/packages/timeline-state-resolver-types/src/atem.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType, DatastoreValue } from '.'
+import { TSRTimelineObjBase, DeviceType } from '.'
 
 export interface MappingAtem extends Mapping {
 	device: DeviceType.ATEM
@@ -134,7 +134,7 @@ export interface TimelineObjAtemME extends TimelineObjAtemBase {
 		type: TimelineContentTypeAtem.ME
 		me: XOR<
 			{
-				input: DatastoreValue<number>
+				input: number
 				transition: AtemTransitionStyle
 			},
 			{

--- a/packages/timeline-state-resolver-types/src/atem.ts
+++ b/packages/timeline-state-resolver-types/src/atem.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, DatastoreValue } from '.'
 
 export interface MappingAtem extends Mapping {
 	device: DeviceType.ATEM
@@ -134,7 +134,7 @@ export interface TimelineObjAtemME extends TimelineObjAtemBase {
 		type: TimelineContentTypeAtem.ME
 		me: XOR<
 			{
-				input: number
+				input: DatastoreValue<number>
 				transition: AtemTransitionStyle
 			},
 			{

--- a/packages/timeline-state-resolver-types/src/atem.ts
+++ b/packages/timeline-state-resolver-types/src/atem.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export interface MappingAtem extends Mapping {
 	device: DeviceType.ATEM
@@ -201,7 +201,7 @@ export interface TimelineObjAtemME extends TimelineObjAtemBase {
 				}
 			}[]
 		}
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjAtemDSK extends TimelineObjAtemBase {
 	content: {
@@ -241,7 +241,7 @@ export interface TimelineObjAtemDSK extends TimelineObjAtemBase {
 				}
 			}
 		}
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjAtemAUX extends TimelineObjAtemBase {
 	content: {
@@ -250,7 +250,7 @@ export interface TimelineObjAtemAUX extends TimelineObjAtemBase {
 		aux: {
 			input: number
 		}
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjAtemSsrc extends TimelineObjAtemBase {
 	content: {
@@ -259,7 +259,7 @@ export interface TimelineObjAtemSsrc extends TimelineObjAtemBase {
 		ssrc: {
 			boxes: Array<SuperSourceBox>
 		}
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 interface AtemSSrcPropsBase {
@@ -328,7 +328,7 @@ export interface TimelineObjAtemSsrcProps extends TimelineObjAtemBase {
 		deviceType: DeviceType.ATEM
 		type: TimelineContentTypeAtem.SSRCPROPS
 		ssrcProps: (AtemSSrcPropsPreMultiplied | AtemSSrcPropsStraight) & (AtemSSrcPropsNoBorder | AtemSSrcPropsBorder)
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjAtemMediaPlayer extends TimelineObjAtemBase {
@@ -347,7 +347,7 @@ export interface TimelineObjAtemMediaPlayer extends TimelineObjAtemBase {
 			atBeginning: boolean
 			clipFrame: number
 		}
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjAtemAudioChannel extends TimelineObjAtemBase {
 	content: {
@@ -361,7 +361,7 @@ export interface TimelineObjAtemAudioChannel extends TimelineObjAtemBase {
 			/** 0: Off, 1: On, 2: AFV */
 			mixOption?: number
 		}
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjAtemMacroPlayer extends TimelineObjAtemBase {
 	content: {
@@ -372,5 +372,5 @@ export interface TimelineObjAtemMacroPlayer extends TimelineObjAtemBase {
 			isRunning: boolean
 			loop?: boolean
 		}
-	}
+	} & TimelineDatastoreReferencesContent
 }

--- a/packages/timeline-state-resolver-types/src/casparcg.ts
+++ b/packages/timeline-state-resolver-types/src/casparcg.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export interface MappingCasparCG extends Mapping {
 	device: DeviceType.CASPARCG
@@ -118,7 +118,8 @@ export interface TimelineObjCCGMedia extends TimelineObjCasparCGBase {
 		/* ffmpeg filter strings for 2.3+ */
 		videoFilter?: string
 		audioFilter?: string
-	} & TimelineObjCCGProducerContentBase
+	} & TimelineObjCCGProducerContentBase &
+		TimelineDatastoreReferencesContent
 }
 export interface TimelineObjCCGIP extends TimelineObjCasparCGBase {
 	content: {
@@ -135,7 +136,8 @@ export interface TimelineObjCCGIP extends TimelineObjCasparCGBase {
 		/* ffmpeg filter strings for 2.3+ */
 		videoFilter?: string
 		audioFilter?: string
-	} & TimelineObjCCGProducerContentBase
+	} & TimelineObjCCGProducerContentBase &
+		TimelineDatastoreReferencesContent
 }
 export interface TimelineObjCCGInput extends TimelineObjCasparCGBase {
 	content: {
@@ -158,7 +160,8 @@ export interface TimelineObjCCGInput extends TimelineObjCasparCGBase {
 		/* ffmpeg filter strings for 2.3+ */
 		videoFilter?: string
 		audioFilter?: string
-	} & TimelineObjCCGProducerContentBase
+	} & TimelineObjCCGProducerContentBase &
+		TimelineDatastoreReferencesContent
 }
 export interface TimelineObjCCGHTMLPage extends TimelineObjCasparCGBase {
 	content: {
@@ -166,7 +169,8 @@ export interface TimelineObjCCGHTMLPage extends TimelineObjCasparCGBase {
 		type: TimelineContentTypeCasparCg.HTMLPAGE
 		/** The URL to load */
 		url: string
-	} & TimelineObjCCGProducerContentBase
+	} & TimelineObjCCGProducerContentBase &
+		TimelineDatastoreReferencesContent
 }
 export interface TimelineObjCCGTemplate extends TimelineObjCasparCGBase {
 	content: {
@@ -180,7 +184,8 @@ export interface TimelineObjCCGTemplate extends TimelineObjCasparCGBase {
 		data?: any
 		/** Whether to use CG stop or CLEAR layer when stopping the template. Defaults to false = CLEAR  */
 		useStopCommand: boolean
-	} & TimelineObjCCGProducerContentBase
+	} & TimelineObjCCGProducerContentBase &
+		TimelineDatastoreReferencesContent
 }
 export interface TimelineObjCCGRoute extends TimelineObjCasparCGBase {
 	content: {
@@ -204,7 +209,8 @@ export interface TimelineObjCCGRoute extends TimelineObjCasparCGBase {
 		/* ffmpeg filter strings for 2.3+ */
 		videoFilter?: string
 		audioFilter?: string
-	} & TimelineObjCCGProducerContentBase
+	} & TimelineObjCCGProducerContentBase &
+		TimelineDatastoreReferencesContent
 }
 export interface TimelineObjCCGRecord extends TimelineObjCasparCGBase {
 	content: {
@@ -214,7 +220,7 @@ export interface TimelineObjCCGRecord extends TimelineObjCasparCGBase {
 		file: string
 		/** ffmpeg encoder options (example '-vcodec libx264 -preset ultrafast') */
 		encoderOptions: string
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 // Note: enums copied from casparcg-connection

--- a/packages/timeline-state-resolver-types/src/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/httpSend.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export interface MappingHTTPSend extends Mapping {
 	device: DeviceType.HTTPSEND
@@ -39,5 +39,6 @@ export interface TimelineObjHTTPSendBase extends TSRTimelineObjBase {
 export interface TimelineObjHTTPRequest extends TimelineObjHTTPSendBase {
 	content: {
 		deviceType: DeviceType.HTTPSEND
-	} & HTTPSendCommandContent
+	} & HTTPSendCommandContent &
+		TimelineDatastoreReferencesContent
 }

--- a/packages/timeline-state-resolver-types/src/hyperdeck.ts
+++ b/packages/timeline-state-resolver-types/src/hyperdeck.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export interface MappingHyperdeck extends Mapping {
 	device: DeviceType.HYPERDECK
@@ -75,7 +75,7 @@ export interface TimelineObjHyperdeck extends TSRTimelineObjBase {
 		deviceType: DeviceType.HYPERDECK
 		/** The type of control of the Hyperdeck */
 		type: TimelineContentTypeHyperdeck
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjHyperdeckTransport extends TimelineObjHyperdeck {
 	content: {
@@ -86,5 +86,5 @@ export interface TimelineObjHyperdeckTransport extends TimelineObjHyperdeck {
 		status: TransportStatus
 		/** The filename to record to */
 		recordFilename?: string
-	}
+	} & TimelineDatastoreReferencesContent
 }

--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -72,9 +72,18 @@ export interface TSRTimelineKeyframe<T> extends Timeline.TimelineKeyframe {
 	content: Partial<T>
 }
 
+/**
+ * An object containing references to the datastore
+ */
 export interface TimelineDatastoreReferences {
 	[key: string]: {
+		/**
+		 * Path to the property in the content object to override
+		 */
 		path: string
+		/**
+		 * Whether the default should override if the timeline object is newer than the datastore value
+		 */
 		overwrite: boolean
 	}
 }

--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -72,16 +72,20 @@ export interface TSRTimelineKeyframe<T> extends Timeline.TimelineKeyframe {
 	content: Partial<T>
 }
 
+export interface TimelineDatastoreReferences {
+	[key: string]: {
+		path: string
+		overwrite: boolean
+	}
+}
+export interface TimelineDatastoreReferencesContent {
+	$references?: TimelineDatastoreReferences
+}
+
 export interface TSRTimelineObjBase extends Omit<Timeline.TimelineObject, 'content'>, TSRTimelineObjProps {
 	content: {
 		deviceType: DeviceType
-		$references?: {
-			[key: string]: {
-				path: any
-				overwrite: boolean
-			}
-		}
-	}
+	} & TimelineDatastoreReferencesContent
 	keyframes?: Array<TSRTimelineKeyframe<this['content']>>
 }
 

--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -68,6 +68,8 @@ export enum DeviceType {
 	OBS = 21,
 }
 
+export type DatastoreValue<T> = T | { _datastoreKey: string; default: T }
+
 export interface TSRTimelineKeyframe<T> extends Timeline.TimelineKeyframe {
 	content: Partial<T>
 }

--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -76,13 +76,14 @@ export interface TSRTimelineKeyframe<T> extends Timeline.TimelineKeyframe {
  * An object containing references to the datastore
  */
 export interface TimelineDatastoreReferences {
-	[key: string]: {
+	/**
+	 * localPath is the path to the property in the content object to override
+	 */
+	[localPath: string]: {
+		/** Reference to the Datastore key where to fetch the value */
+		datastoreKey: string
 		/**
-		 * Path to the property in the content object to override
-		 */
-		path: string
-		/**
-		 * Whether the default should override if the timeline object is newer than the datastore value
+		 * If true, the referenced value in the Datastore is only applied after the timeline-object has started (ie a later-started timeline-object will not be affected)
 		 */
 		overwrite: boolean
 	}
@@ -137,3 +138,15 @@ export type TSRTimelineObj =
 	| TimelineObjVIZMSEAny
 
 export type TSRTimeline = Array<TSRTimelineObj>
+
+/**
+ * A simple key value store that can be referred to from the timeline objects
+ */
+export interface Datastore {
+	[datastoreKey: string]: {
+		/** The value that will replace a value in the Timeline-object content */
+		value: any
+		/** A unix-Timestamp of when the value was set. (Note that this must not be set a value in the future.) */
+		modified: number
+	}
+}

--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -68,8 +68,6 @@ export enum DeviceType {
 	OBS = 21,
 }
 
-export type DatastoreValue<T> = T | { _datastoreKey: string; default: T }
-
 export interface TSRTimelineKeyframe<T> extends Timeline.TimelineKeyframe {
 	content: Partial<T>
 }
@@ -77,6 +75,12 @@ export interface TSRTimelineKeyframe<T> extends Timeline.TimelineKeyframe {
 export interface TSRTimelineObjBase extends Omit<Timeline.TimelineObject, 'content'>, TSRTimelineObjProps {
 	content: {
 		deviceType: DeviceType
+		$references?: {
+			[key: string]: {
+				path: any
+				overwrite: boolean
+			}
+		}
 	}
 	keyframes?: Array<TSRTimelineKeyframe<this['content']>>
 }

--- a/packages/timeline-state-resolver-types/src/lawo.ts
+++ b/packages/timeline-state-resolver-types/src/lawo.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export type EmberValue = number | string | boolean | Buffer | null
 enum ParameterType {
@@ -96,7 +96,7 @@ export interface TimelineObjLawoSources extends TimelineObjLawoBase {
 			} & ContentTimelineObjLawoSource
 		>
 		overridePriority?: number // defaults to 0
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjLawoSource extends TimelineObjLawoBase {
 	content: {
@@ -104,19 +104,20 @@ export interface TimelineObjLawoSource extends TimelineObjLawoBase {
 		type: TimelineContentTypeLawo.SOURCE
 
 		overridePriority?: number // defaults to 0
-	} & ContentTimelineObjLawoSource
+	} & ContentTimelineObjLawoSource &
+		TimelineDatastoreReferencesContent
 }
 export interface TimelineObjLawoEmberProperty extends TimelineObjLawoBase {
 	content: {
 		deviceType: DeviceType.LAWO
 		type: TimelineContentTypeLawo.EMBER_PROPERTY
 		value: EmberValue
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjLawoEmberRetrigger extends TimelineObjLawoBase {
 	content: {
 		deviceType: DeviceType.LAWO
 		type: TimelineContentTypeLawo.TRIGGER_VALUE
 		triggerValue: string
-	}
+	} & TimelineDatastoreReferencesContent
 }

--- a/packages/timeline-state-resolver-types/src/obs.ts
+++ b/packages/timeline-state-resolver-types/src/obs.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export type MappingOBSAny =
 	| MappingOBSCurrentScene
@@ -117,7 +117,7 @@ export interface TimelineObjOBSCurrentScene extends TimelineObjOBSBase {
 
 		/** Name of the scene that should be current */
 		sceneName: string
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjOBSCurrentTransition extends TimelineObjOBSBase {
@@ -127,7 +127,7 @@ export interface TimelineObjOBSCurrentTransition extends TimelineObjOBSBase {
 
 		/** Name of the transition that should be current */
 		transitionName: string
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjOBSRecording extends TimelineObjOBSBase {
@@ -137,7 +137,7 @@ export interface TimelineObjOBSRecording extends TimelineObjOBSBase {
 
 		/** Should recording be turned on */
 		on: boolean
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjOBSStreaming extends TimelineObjOBSBase {
@@ -147,7 +147,7 @@ export interface TimelineObjOBSStreaming extends TimelineObjOBSBase {
 
 		/** Should streaming be turned on */
 		on: boolean
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjOBSSceneItemRender extends TimelineObjOBSBase {

--- a/packages/timeline-state-resolver-types/src/osc.ts
+++ b/packages/timeline-state-resolver-types/src/osc.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 // Note: This type is a loose referral to (a copy of) keyof typeof Easing in '../../easings', so that Easing structure won't be included in the types package
 export type OSCEasingType =
@@ -61,7 +61,7 @@ export interface OSCValueBoolean {
 }
 export type SomeOSCValue = OSCValueNumber | OSCValueString | OSCValueBlob | OSCValueBoolean
 
-export interface OSCMessageCommandContent {
+export interface OSCMessageCommandContent extends TimelineDatastoreReferencesContent {
 	type: TimelineContentTypeOSC.OSC
 	path: string
 	values: SomeOSCValue[]

--- a/packages/timeline-state-resolver-types/src/panasonicPTZ.ts
+++ b/packages/timeline-state-resolver-types/src/panasonicPTZ.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export interface MappingPanasonicPtz extends Mapping {
 	device: DeviceType.PANASONIC_PTZ
@@ -34,14 +34,14 @@ export interface TimelineObjPanasonicPtz extends TSRTimelineObjBase {
 	content: {
 		deviceType: DeviceType.PANASONIC_PTZ
 		type: TimelineContentTypePanasonicPtz
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjPanasonicPtzZoomSpeed extends TimelineObjPanasonicPtz {
 	content: {
 		deviceType: DeviceType.PANASONIC_PTZ
 		type: TimelineContentTypePanasonicPtz.ZOOM_SPEED
 		zoomSpeed: number
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjPanasonicPtzZoom extends TimelineObjPanasonicPtz {
@@ -49,7 +49,7 @@ export interface TimelineObjPanasonicPtzZoom extends TimelineObjPanasonicPtz {
 		deviceType: DeviceType.PANASONIC_PTZ
 		type: TimelineContentTypePanasonicPtz.ZOOM
 		zoom: number
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjPanasonicPtzPresetSpeed extends TimelineObjPanasonicPtz {
@@ -57,7 +57,7 @@ export interface TimelineObjPanasonicPtzPresetSpeed extends TimelineObjPanasonic
 		deviceType: DeviceType.PANASONIC_PTZ
 		type: TimelineContentTypePanasonicPtz.SPEED
 		speed: number
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjPanasonicPtzPreset extends TimelineObjPanasonicPtz {
@@ -65,5 +65,5 @@ export interface TimelineObjPanasonicPtzPreset extends TimelineObjPanasonicPtz {
 		deviceType: DeviceType.PANASONIC_PTZ
 		type: TimelineContentTypePanasonicPtz.PRESET
 		preset: number
-	}
+	} & TimelineDatastoreReferencesContent
 }

--- a/packages/timeline-state-resolver-types/src/pharos.ts
+++ b/packages/timeline-state-resolver-types/src/pharos.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export interface PharosOptions {
 	host: string
@@ -36,7 +36,7 @@ export interface TimelineObjPharosScene extends TimelineObjPharos {
 
 		scene: number
 		fade?: number
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjPharosTimeline extends TimelineObjPharos {
 	content: {
@@ -49,5 +49,5 @@ export interface TimelineObjPharosTimeline extends TimelineObjPharos {
 		pause?: boolean
 		rate?: boolean
 		fade?: number
-	}
+	} & TimelineDatastoreReferencesContent
 }

--- a/packages/timeline-state-resolver-types/src/quantel.ts
+++ b/packages/timeline-state-resolver-types/src/quantel.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { DeviceType, TSRTimelineObjBaseWithOnAir } from '.'
+import { DeviceType, TimelineDatastoreReferencesContent, TSRTimelineObjBaseWithOnAir } from '.'
 
 export interface MappingQuantel extends Mapping {
 	device: DeviceType.QUANTEL
@@ -67,7 +67,7 @@ export interface TimelineObjQuantelClip extends TSRTimelineObjBaseWithOnAir {
 
 		// inTransition?: QuantelTransition
 		outTransition?: QuantelOutTransition
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export type QuantelOutTransition = QuantelTransitionDelay
 export interface QuantelTransitionBase {

--- a/packages/timeline-state-resolver-types/src/shotoku.ts
+++ b/packages/timeline-state-resolver-types/src/shotoku.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export interface ShotokuOptions {
 	host: string
@@ -30,7 +30,8 @@ export interface TimelineObjShotokuShot extends TSRTimelineObjBase {
 	content: {
 		deviceType: DeviceType.SHOTOKU
 		type: TimelineContentTypeShotoku.SHOT
-	} & ShotokuCommandContent
+	} & ShotokuCommandContent &
+		TimelineDatastoreReferencesContent
 }
 export interface TimelineObjShotokuSequence extends TSRTimelineObjBase {
 	content: {
@@ -43,7 +44,7 @@ export interface TimelineObjShotokuSequence extends TSRTimelineObjBase {
 				offset: number
 			} & ShotokuCommandContent
 		>
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export type TimelineObjShotoku = TimelineObjShotokuShot | TimelineObjShotokuSequence

--- a/packages/timeline-state-resolver-types/src/singularLive.ts
+++ b/packages/timeline-state-resolver-types/src/singularLive.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export interface MappingSingularLive extends Mapping {
 	device: DeviceType.SINGULAR_LIVE
@@ -26,7 +26,7 @@ export interface TimelineObjSingularLiveBase extends TSRTimelineObjBase {
 	content: {
 		deviceType: DeviceType.SINGULAR_LIVE
 		type: TimelineContentTypeSingularLive
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjSingularLiveComposition extends TimelineObjSingularLiveBase {
@@ -36,7 +36,7 @@ export interface TimelineObjSingularLiveComposition extends TimelineObjSingularL
 
 		animation?: SingularCompositionAnimation
 		controlNode: SingularCompositionControlNode
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface SingularCompositionAnimation {
 	action: 'jump' | 'play'

--- a/packages/timeline-state-resolver-types/src/sisyfos.ts
+++ b/packages/timeline-state-resolver-types/src/sisyfos.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { DeviceType, TSRTimelineObjBase } from '.'
+import { DeviceType, TimelineDatastoreReferencesContent, TSRTimelineObjBase } from '.'
 
 export interface SisyfosOptions {
 	host: string
@@ -60,7 +60,7 @@ export interface TimelineObjSisyfosTriggerValue extends TimelineObjSisyfos {
 		type: TimelineContentTypeSisyfos.TRIGGERVALUE
 
 		triggerValue: string
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjSisyfosChannel extends TimelineObjSisyfos {
 	content: {
@@ -68,7 +68,8 @@ export interface TimelineObjSisyfosChannel extends TimelineObjSisyfos {
 		type: TimelineContentTypeSisyfos.CHANNEL
 		resync?: boolean
 		overridePriority?: number // defaults to 0
-	} & SisyfosChannelOptions
+	} & SisyfosChannelOptions &
+		TimelineDatastoreReferencesContent
 }
 export interface TimelineObjSisyfosChannels extends TimelineObjSisyfos {
 	content: {
@@ -81,5 +82,5 @@ export interface TimelineObjSisyfosChannels extends TimelineObjSisyfos {
 		resync?: boolean
 		overridePriority?: number // defaults to 0
 		triggerValue?: string
-	}
+	} & TimelineDatastoreReferencesContent
 }

--- a/packages/timeline-state-resolver-types/src/tcpSend.ts
+++ b/packages/timeline-state-resolver-types/src/tcpSend.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export interface MappingTCPSend extends Mapping {
 	device: DeviceType.TCPSEND
@@ -33,10 +33,11 @@ export type TimelineObjTCPSendAny = TimelineObjTCPRequest
 export interface TimelineObjTCPSendBase extends TSRTimelineObjBase {
 	content: {
 		deviceType: DeviceType.TCPSEND
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjTCPRequest extends TimelineObjTCPSendBase {
 	content: {
 		deviceType: DeviceType.TCPSEND
-	} & TcpSendCommandContent
+	} & TcpSendCommandContent &
+		TimelineDatastoreReferencesContent
 }

--- a/packages/timeline-state-resolver-types/src/vizMSE.ts
+++ b/packages/timeline-state-resolver-types/src/vizMSE.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export interface MappingVizMSE extends Mapping {
 	device: DeviceType.VIZMSE
@@ -83,7 +83,7 @@ export interface TimelineObjVIZMSEBase extends TSRTimelineObjBase {
 
 		// inTransition?: VIZMSEOutTransition
 		outTransition?: VIZMSEOutTransition
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjVIZMSEElementInternal extends TimelineObjVIZMSEBase {
 	content: {
@@ -113,7 +113,7 @@ export interface TimelineObjVIZMSEElementInternal extends TimelineObjVIZMSEBase 
 		showId: string
 		/** Whether this element should have its take delayed until after an out transition has finished */
 		delayTakeAfterOutTransition?: boolean
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjVIZMSEElementPilot extends TimelineObjVIZMSEBase {
 	content: {
@@ -139,7 +139,7 @@ export interface TimelineObjVIZMSEElementPilot extends TimelineObjVIZMSEBase {
 		templateVcpId: number
 		/** Whether this element should have its take delayed until after an out transition has finished */
 		delayTakeAfterOutTransition?: boolean
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjVIZMSEElementContinue extends TSRTimelineObjBase {
 	content: {
@@ -151,13 +151,13 @@ export interface TimelineObjVIZMSEElementContinue extends TSRTimelineObjBase {
 
 		/** What other layer to continue */
 		reference: string
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjVIZMSELoadAllElements extends TSRTimelineObjBase {
 	content: {
 		deviceType: DeviceType.VIZMSE
 		type: TimelineContentTypeVizMSE.LOAD_ALL_ELEMENTS
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjVIZMSEClearAllElements extends TSRTimelineObjBase {
 	content: {
@@ -169,7 +169,7 @@ export interface TimelineObjVIZMSEClearAllElements extends TSRTimelineObjBase {
 
 		/** IDs of the Show to use for taking the special template */
 		showId: string
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjVIZMSEInitializeShows extends TSRTimelineObjBase {
 	content: {
@@ -178,7 +178,7 @@ export interface TimelineObjVIZMSEInitializeShows extends TSRTimelineObjBase {
 
 		/** IDs of the Shows to initialize */
 		showIds: string[]
-	}
+	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjVIZMSECleanupShows extends TSRTimelineObjBase {
 	content: {
@@ -187,7 +187,7 @@ export interface TimelineObjVIZMSECleanupShows extends TSRTimelineObjBase {
 
 		/** IDs of the Shows to cleanup */
 		showIds: string[]
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVIZMSEConcept extends TimelineObjVIZMSEBase {
@@ -195,7 +195,7 @@ export interface TimelineObjVIZMSEConcept extends TimelineObjVIZMSEBase {
 		deviceType: DeviceType.VIZMSE
 		type: TimelineContentTypeVizMSE.CONCEPT
 		concept: string
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export type VIZMSEOutTransition = VIZMSETransitionDelay

--- a/packages/timeline-state-resolver-types/src/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/vmix.ts
@@ -1,5 +1,5 @@
 import { Mapping } from './mapping'
-import { TSRTimelineObjBase, DeviceType } from '.'
+import { TSRTimelineObjBase, DeviceType, TimelineDatastoreReferencesContent } from '.'
 
 export type MappingVMixAny =
 	| MappingVMixProgram
@@ -174,7 +174,7 @@ export interface TimelineObjVMixBase extends TSRTimelineObjBase {
 	content: {
 		deviceType: DeviceType.VMIX
 		type: TimelineContentTypeVMix
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixProgram extends TimelineObjVMixBase {
@@ -190,7 +190,7 @@ export interface TimelineObjVMixProgram extends TimelineObjVMixBase {
 
 		/** Transition effect (Stingers work only for Mix number 1) */
 		transition?: VMixTransition
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixPreview extends TimelineObjVMixBase {
@@ -200,7 +200,7 @@ export interface TimelineObjVMixPreview extends TimelineObjVMixBase {
 
 		/** Input number or name */
 		input: number | string
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixAudio extends TimelineObjVMixBase {
@@ -225,7 +225,7 @@ export interface TimelineObjVMixAudio extends TimelineObjVMixBase {
 
 		/** Audio follow video */
 		audioAuto?: boolean
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixFader extends TimelineObjVMixBase {
@@ -235,7 +235,7 @@ export interface TimelineObjVMixFader extends TimelineObjVMixBase {
 
 		/** Position of the transition fader (0 - 255) */
 		position: number
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixStreaming extends TimelineObjVMixBase {
@@ -245,7 +245,7 @@ export interface TimelineObjVMixStreaming extends TimelineObjVMixBase {
 
 		/** If streaming should be turned on */
 		on: boolean
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixRecording extends TimelineObjVMixBase {
@@ -255,7 +255,7 @@ export interface TimelineObjVMixRecording extends TimelineObjVMixBase {
 
 		/** If recording should be turned on */
 		on: boolean
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixFadeToBlack extends TimelineObjVMixBase {
@@ -265,7 +265,7 @@ export interface TimelineObjVMixFadeToBlack extends TimelineObjVMixBase {
 
 		/** If Fade To Black should be turned on */
 		on: boolean
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixInput extends TimelineObjVMixBase {
@@ -292,7 +292,7 @@ export interface TimelineObjVMixInput extends TimelineObjVMixBase {
 
 		/** List of input (Multi View) overlays; indexes start from 1 */
 		overlays?: VMixInputOverlays
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixOutput extends TimelineObjVMixBase {
@@ -305,7 +305,7 @@ export interface TimelineObjVMixOutput extends TimelineObjVMixBase {
 
 		/** Number/name of the input when source:'Input' is chosen */
 		input?: number | string
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixExternal extends TimelineObjVMixBase {
@@ -315,7 +315,7 @@ export interface TimelineObjVMixExternal extends TimelineObjVMixBase {
 
 		/** If external should be turned on */
 		on: boolean
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface TimelineObjVMixOverlay extends TimelineObjVMixBase {
@@ -325,7 +325,7 @@ export interface TimelineObjVMixOverlay extends TimelineObjVMixBase {
 
 		/** Input number or name */
 		input: number | string
-	}
+	} & TimelineDatastoreReferencesContent
 }
 
 export interface VMixTransform {

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -18,6 +18,7 @@ import {
 	ResolvedTimelineObjectInstanceExtended,
 	TSRTimeline,
 	DeviceOptionsBase,
+	TimelineDatastoreReferences,
 } from 'timeline-state-resolver-types'
 import { AtemDevice, DeviceOptionsAtemInternal } from './devices/atem'
 import { EventEmitter } from 'eventemitter3'
@@ -44,6 +45,7 @@ import * as PAll from 'p-all'
 import PTimeout from 'p-timeout'
 import { ShotokuDevice, DeviceOptionsShotokuInternal } from './devices/shotoku'
 import { endTrace, fillStateFromDatastore, FinishedTrace, startTrace } from './lib'
+import { Datastore } from 'timeline-state-resolver-types/src'
 
 export { DeviceContainer }
 export { CommandWithContext }
@@ -113,12 +115,6 @@ export interface StatReport {
 	timelineSize: number
 	timelineSizeOld: number
 	estimatedResolveTime: number
-}
-export interface Datastore {
-	[key: string]: {
-		value: any
-		modified: number
-	}
 }
 
 export type ConductorEvents = {
@@ -1084,7 +1080,9 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 
 		// find all references to the datastore that are in this state
 		const dependencies: string[] = Object.values(state.layers).flatMap(({ content }) =>
-			Object.keys(content.$references || {})
+			Object.values(content.$references || {}).map((r: TimelineDatastoreReferences[any]): string => {
+				return r.datastoreKey
+			})
 		)
 
 		// store all states between the current state and the new state

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -1131,7 +1131,7 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 			if (this._datastore[key] !== newStore[key]) {
 				// it changed! let's sift through our dependencies to see if we need to do anything
 				Object.entries(this._deviceStates).forEach(([deviceId, states]) => {
-					if (states.find((state) => state.dependencies.find((deps) => deps === 'key'))) {
+					if (states.find((state) => state.dependencies.find((deps) => deps === key))) {
 						changed.push(deviceId)
 					}
 				})

--- a/packages/timeline-state-resolver/src/lib.ts
+++ b/packages/timeline-state-resolver/src/lib.ts
@@ -1,7 +1,6 @@
 import { TimelineState } from 'superfly-timeline'
-import { TSRTimelineObjBase } from 'timeline-state-resolver-types'
+import { TSRTimelineObjBase, Datastore } from 'timeline-state-resolver-types'
 import * as _ from 'underscore'
-import { Datastore } from './conductor'
 
 /**
  * getDiff is the reverse of underscore:s _.isEqual(): It compares two values and if they differ it returns an explanation of the difference
@@ -237,17 +236,17 @@ export function fillStateFromDatastore(state: TimelineState, datastore: Datastor
 
 	Object.values(filledState.layers).forEach(({ content, instance }) => {
 		if ((content as TSRTimelineObjBase['content']).$references) {
-			Object.entries((content as TSRTimelineObjBase['content']).$references || {}).forEach(([key, ref]) => {
-				const datastoreVal = datastore[key]
+			Object.entries((content as TSRTimelineObjBase['content']).$references || {}).forEach(([path, ref]) => {
+				const datastoreVal = datastore[ref.datastoreKey]
 
 				if (datastoreVal !== undefined) {
 					if (ref.overwrite) {
 						// only use the datastore value if it was changed after the tl obj started
 						if ((instance.originalStart || instance.start || 0) <= datastoreVal.modified) {
-							set(content, ref.path, datastoreVal.value)
+							set(content, path, datastoreVal.value)
 						}
 					} else {
-						set(content, ref.path, datastoreVal.value)
+						set(content, path, datastoreVal.value)
 					}
 				}
 			})


### PR DESCRIPTION
This PR introduces a concept known as the _Timeline Datastore_. The datastore is a key value store that can be referenced from the content of a timeline object. When the timeline is resolved the references are replaced by the current value of the reference. If the timeline object started after the last update to the Timeline Datastore it may use a default value instead. 

Proposed API for timeline objects:
```ts
const mixEffect0: TSRTimelineObj = {
    id: 'me0',
    enable: {
        start: Date.now(),
    },
    layer: 'me0',
    content: {
        deviceType: DeviceType.ATEM,
        type: TimelineContentTypeAtem.MixEffect,

        $references: {
            input: { // the datastore key
                path: 'me.input', // property to override
                overwrite: false, // whether the default should override if the object is newer than the datastore value
            }
        },

        me: {
            input: 1,
            transition: AtemTransitionStyle.Cut
        }
    },
}
```
Proposed format of the datastore:
```ts
const ds = {
    'input': {
        value: 2, // the value to place into the timeline object
        modified: Date.now(), // when the datastore value was last updated
    }
}
```

This is a relatively small change to the TSR API but it allows systems using the TSR to control devices using very small database updates instead of updating the entire timeline. It's usage is entirely optional.