### PR TITLE
fix: timeout a device terminate operation if it takes too long and force-terminate

### DIFF
--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -105,7 +105,7 @@
 		"request": "^2.88.0",
 		"sprintf-js": "^1.1.2",
 		"superfly-timeline": "^8.2.7",
-		"threadedclass": "^1.1.0",
+		"threadedclass": "^1.1.1",
 		"timeline-state-resolver-types": "7.3.0-release44.1",
 		"tslib": "^2.3.1",
 		"tv-automation-quantel-gateway-client": "^2.0.4",

--- a/packages/timeline-state-resolver/src/devices/casparCG.ts
+++ b/packages/timeline-state-resolver/src/devices/casparCG.ts
@@ -164,6 +164,10 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 		this._transitionHandler.terminate()
 		clearTimeout(this._retryTimeout)
 		return new Promise((resolve) => {
+			if (!this._ccg) {
+				resolve(true)
+				return
+			}
 			this._ccg.disconnect()
 			this._ccg.onDisconnected = () => {
 				resolve(true)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8059,10 +8059,10 @@ threadedclass@^0.8.0:
     is-running "^2.1.0"
     tslib "^1.13.0"
 
-threadedclass@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/threadedclass/-/threadedclass-1.1.0.tgz#3f0e3e91d41098a9c9aa98635fa043530702e269"
-  integrity sha512-+R9wHIHKMsmp0g1TKHZ9gcATD5Pohig4ZWqDqV2o1+VjKjw8KmUcTQZ0sJCj/G8hjFxXPp2QAZDHsmzTcqQJYQ==
+threadedclass@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/threadedclass/-/threadedclass-1.1.1.tgz#6813b3c401b3d55264f6225c9d2c15516d7efa97"
+  integrity sha512-HffBjerRZGOlhUBt9Ue8nYCuV6khK9er86w4svTvf1Xn6ibAyJok290o2MJ/qJ1vy0A4UphEo3DSsxFN5g+TBQ==
   dependencies:
     callsites "^3.1.0"
     eventemitter3 "^4.0.4"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix

* **What is the current behavior?** (You can also link to an open issue here)

If a device is not initialized because the device thread crashed, or for some other reason the device fails to `terminate()` running _removeDevice will wait forever for it to do so.

* **What is the new behavior (if this is a feature change)?**

This adds a timeout, so that the removal process can progress and the thread can be terminated.

* **Other information**:
