### PR TITLE
fix: threaded class error handler

### DIFF
--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -590,6 +590,9 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 			}
 
 			newDevice.device.on('resetResolver', () => this.resetResolver()).catch(console.error)
+			newDevice.on('error', (context, e) => {
+				this.emit('error', `deviceContainer for "${newDevice?.deviceId}" emitted an error: ${context}, ${e}`)
+			})
 
 			// Double check that it hasnt been created while we were busy waiting
 			if (this.devices.has(deviceId)) {

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -243,6 +243,17 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 			}
 		)
 
+		ThreadedClassManager.onEvent(this._resolver, 'thread_closed', () => {
+			// This is called if a child crashes - we are using autoRestart, so we just log
+			this.emit('warning', 'AsyncResolver thread closed')
+		})
+		ThreadedClassManager.onEvent(this._resolver, 'restarted', () => {
+			this.emit('warning', 'AsyncResolver thread restarted')
+		})
+		ThreadedClassManager.onEvent(this._resolver, 'error', (error: any) => {
+			this.emit('error', 'AsyncResolver threadedClass error', error)
+		})
+
 		this._isInitialized = true
 		this.resetResolver()
 	}

--- a/packages/timeline-state-resolver/src/devices/deviceContainer.ts
+++ b/packages/timeline-state-resolver/src/devices/deviceContainer.ts
@@ -66,7 +66,7 @@ export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> extends Ev
 					if (container.onChildClose) container.onChildClose()
 				}),
 				ThreadedClassManager.onEvent(container._device, 'error', (error) => {
-					container.emit('error', 'threadedClass', error)
+					container.emit('error', `${orgClassExport} "${deviceId}" threadedClass error`, error)
 				}),
 			]
 		}

--- a/packages/timeline-state-resolver/src/devices/deviceContainer.ts
+++ b/packages/timeline-state-resolver/src/devices/deviceContainer.ts
@@ -1,13 +1,18 @@
 import { ThreadedClass, threadedClass, ThreadedClassConfig, ThreadedClassManager } from 'threadedclass'
 import { Device } from './device'
 import { DeviceType, DeviceOptionsBase } from 'timeline-state-resolver-types'
+import { EventEmitter } from 'eventemitter3'
+
+export type DeviceContainerEvents = {
+	error: [context: string, err: Error]
+}
 
 /**
  * A device container is a wrapper around a device in ThreadedClass class, it
  * keeps a local property of some basic information about the device (like
  * names and id's) to prevent a costly round trip over IPC.
  */
-export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> {
+export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> extends EventEmitter<DeviceContainerEvents> {
 	private _device: ThreadedClass<Device<TOptions>>
 	private _deviceId = 'N/A'
 	private _deviceType: DeviceType
@@ -17,11 +22,12 @@ export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> {
 	public onChildClose: () => void | undefined
 	private _instanceId = -1
 	private _startTime = -1
-	private _onEventListener: { stop: () => void } | undefined
+	private _onEventListeners: { stop: () => void }[] | undefined
 	private _debugLogging = true
 	private _initialized = false
 
 	private constructor(deviceOptions: TOptions, threadConfig?: ThreadedClassConfig) {
+		super()
 		this._deviceOptions = deviceOptions
 		this._threadConfig = threadConfig
 		this._debugLogging = deviceOptions.debug || false
@@ -54,10 +60,15 @@ export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> {
 		)
 
 		if (deviceOptions.isMultiThreaded) {
-			container._onEventListener = ThreadedClassManager.onEvent(container._device, 'thread_closed', () => {
-				// This is called if a child crashes
-				if (container.onChildClose) container.onChildClose()
-			})
+			container._onEventListeners = [
+				ThreadedClassManager.onEvent(container._device, 'thread_closed', () => {
+					// This is called if a child crashes
+					if (container.onChildClose) container.onChildClose()
+				}),
+				ThreadedClassManager.onEvent(container._device, 'error', (error) => {
+					container.emit('error', 'threadedClass', error)
+				}),
+			]
 		}
 
 		await container.reloadProps()
@@ -88,8 +99,8 @@ export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> {
 	}
 
 	public async terminate() {
-		if (this._onEventListener) {
-			this._onEventListener.stop()
+		if (this._onEventListeners) {
+			this._onEventListeners.forEach((listener) => listener.stop())
 		}
 		await ThreadedClassManager.destroy(this._device)
 	}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix

* **What is the current behavior?** (You can also link to an open issue here)

There is no `error` event handler registered on the device threads, meaning that if a device throws a thread-level error, nothing is there to catch it and log it.

* **What is the new behavior (if this is a feature change)?**

Add an event handler to catch the errors. This should also improve the stability, because an uncaught error in the threadedClass could crash the entire playout gateway.

* **Other information**:
