### PR TITLE
fix: re-adds a check for clearAllOnMakeReady before doing so

### DIFF
--- a/packages/timeline-state-resolver/src/__mocks__/net.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/net.ts
@@ -33,12 +33,15 @@ export class Socket extends EventEmitter {
 	// this.emit('close')
 	// this.emit('end')
 
-	public connect(port: number, host: string) {
+	public connect(port: number, host: string, cb?: () => void) {
 		// this._port = port
 		// this._host = host
 
 		if (this.onConnect) this.onConnect(port, host)
 		setTimeoutOrg(() => {
+			if (cb) {
+				cb()
+			}
 			this.setConnected()
 		}, 3)
 	}

--- a/packages/timeline-state-resolver/src/__mocks__/net.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/net.ts
@@ -33,7 +33,7 @@ export class Socket extends EventEmitter {
 	// this.emit('close')
 	// this.emit('end')
 
-	public connect(port: number, host: string, cb?: () => void) {
+	public connect(port: number, host = 'localhost', cb?: () => void) {
 		// this._port = port
 		// this._host = host
 

--- a/packages/timeline-state-resolver/src/__mocks__/net.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/net.ts
@@ -33,13 +33,12 @@ export class Socket extends EventEmitter {
 	// this.emit('close')
 	// this.emit('end')
 
-	public connect(port, host, cb) {
+	public connect(port: number, host: string) {
 		// this._port = port
 		// this._host = host
 
 		if (this.onConnect) this.onConnect(port, host)
 		setTimeoutOrg(() => {
-			cb()
 			this.setConnected()
 		}, 3)
 	}

--- a/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
@@ -15,6 +15,7 @@ import {
 	ElementId,
 	isInternalElement,
 	isExternalElement,
+	VExecutionGroup,
 } from '@tv2media/v-connection'
 import { EventEmitter } from 'events'
 import { CommandResult } from '@tv2media/v-connection/dist/msehttp'
@@ -46,6 +47,7 @@ export class MSEMock extends EventEmitter implements MSE {
 	public readonly wsPort: number
 	public readonly resthost: string
 
+	private engines: VizEngine[] = []
 	private profiles: { [profileName: string]: VProfile } = {}
 	private rundowns: { [playlistId: string]: VRundownMock } = {}
 
@@ -66,16 +68,18 @@ export class MSEMock extends EventEmitter implements MSE {
 		return rundown
 	}
 	async getEngines(): Promise<VizEngine[]> {
-		return []
+		return this.engines
 	}
 	async listProfiles(): Promise<string[]> {
 		return _.keys(this.profiles) // ?
 	}
 	async getProfile(profileName: string): Promise<VProfile> {
-		return {
-			name: profileName,
-			execution_groups: {},
-		}
+		return (
+			this.profiles[profileName] || {
+				name: profileName,
+				execution_groups: {},
+			}
+		)
 	}
 	async listShows(): Promise<string[]> {
 		return []
@@ -114,12 +118,11 @@ export class MSEMock extends EventEmitter implements MSE {
 		return false
 	}
 	async createProfile(profileName: string, _profileDetailsTbc: any): Promise<VProfile> {
-		const profile: VProfile = {
-			name: profileName,
-			execution_groups: {},
-		}
+		return this.mockCreateProfile(profileName, {})
+	}
+	public mockCreateProfile(profileName: string, execution_groups: { [group: string]: VExecutionGroup }): VProfile {
+		const profile = { name: profileName, execution_groups }
 		this.profiles[profileName] = profile
-
 		return profile
 	}
 	async deleteProfile(profileName: string): Promise<boolean> {
@@ -156,6 +159,9 @@ export class MSEMock extends EventEmitter implements MSE {
 	}
 	mockSetDisconnected() {
 		this.emit('disconnected')
+	}
+	mockSetEngines(engines: VizEngine[]) {
+		this.engines = engines
 	}
 }
 

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -360,7 +360,11 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 			this.clearStates()
 
 			if (this._vizmseManager) {
-				if (this._initOptions && activeRundownPlaylistId !== previousPlaylistId) {
+				if (
+					this._initOptions &&
+					this._initOptions.clearAllOnMakeReady &&
+					activeRundownPlaylistId !== previousPlaylistId
+				) {
 					if (this._initOptions.clearAllCommands && this._initOptions.clearAllCommands.length) {
 						await this._vizmseManager.clearEngines({
 							type: VizMSECommandType.CLEAR_ALL_ENGINES,

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -360,12 +360,12 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 			this.clearStates()
 
 			if (this._vizmseManager) {
-				if (
-					this._initOptions &&
-					this._initOptions.clearAllOnMakeReady &&
-					activeRundownPlaylistId !== previousPlaylistId
-				) {
-					if (this._initOptions.clearAllCommands && this._initOptions.clearAllCommands.length) {
+				if (this._initOptions && activeRundownPlaylistId !== previousPlaylistId) {
+					if (
+						this._initOptions.clearAllOnMakeReady &&
+						this._initOptions.clearAllCommands &&
+						this._initOptions.clearAllCommands.length
+					) {
 						await this._vizmseManager.clearEngines({
 							type: VizMSECommandType.CLEAR_ALL_ENGINES,
 							time: this.getCurrentTime(),

--- a/packages/timeline-state-resolver/src/devices/vizMSE.ts
+++ b/packages/timeline-state-resolver/src/devices/vizMSE.ts
@@ -2266,7 +2266,6 @@ class VizEngineTcpSender extends EventEmitter {
 	}
 
 	private _connect() {
-		this._socket = net.createConnection(this._port, this._host)
 		this._socket.on('connect', () => {
 			this._connected = true
 			if (this._sendQueue.length) {
@@ -2281,6 +2280,7 @@ class VizEngineTcpSender extends EventEmitter {
 			// this handles a dns exception, but the error is handled on 'error' event
 		})
 		this._socket.on('data', this._processData.bind(this))
+		this._socket.connect(this._port, this._host)
 	}
 
 	private _flushQueue() {


### PR DESCRIPTION
* **What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix, re-adding a feature missing since May 2nd.

* **What is the current behavior? (You can also link to an open issue here)**
If Clear-commands are specified, they will run on each rundown activation.

* **What is the new behavior (if this is a feature change)?**
Clear-commands will only run (if specified) AND the option clearAllOnMakeRady is set to true.

* **Other information:**
Without this change, the option clearAllOnMakeReady is useless/not being used anywhere, and should be removed.