### PR TITLE
Fix: Viz: purge rundown

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
@@ -1018,6 +1018,13 @@ class VizMSEManager extends EventEmitter {
 				.catch((error) => this.emit('error', error))
 		}
 	}
+	public async purgeRundown(clearAll: boolean): Promise<void> {
+		this.emit('debug', `VizMSE: purging rundown (manually)`)
+
+		const rundown = await this._getRundown()
+		const elementsToKeep = clearAll ? undefined : this.getElementsToKeep()
+		await rundown.purgeExternalElements(elementsToKeep)
+	}
 	/**
 	 * Activate the rundown.
 	 * This causes the MSE rundown to activate, which must be done before using it.
@@ -1033,11 +1040,8 @@ class VizMSEManager extends EventEmitter {
 			// clear any existing elements from the existing rundown
 			try {
 				this.emit('debug', `VizMSE: purging rundown`)
-				const elementsToKeep = this._expectedPlayoutItems
-					.filter((item) => !!item.baseline)
-					.map((playoutItem) => VizMSEManager.getPlayoutItemContent(playoutItem))
-					.filter(isVizMSEPlayoutItemContentExternalInstance)
 
+				const elementsToKeep = this.getElementsToKeep()
 				await rundown.purgeExternalElements(elementsToKeep)
 			} catch (error) {
 				this.emit('error', error)
@@ -2016,6 +2020,12 @@ class VizMSEManager extends EventEmitter {
 				resolve(false)
 			}, delay || 0)
 		})
+	}
+	private getElementsToKeep(): VIZMSEPlayoutItemContentExternal[] {
+		return this._expectedPlayoutItems
+			.filter((item) => !!item.baseline)
+			.map((playoutItem) => VizMSEManager.getPlayoutItemContent(playoutItem))
+			.filter(isVizMSEPlayoutItemContentExternalInstance)
 	}
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add method to Viz device


* **What is the current behavior?** (You can also link to an open issue here)
-


* **What is the new behavior (if this is a feature change)?**
This PR adds a method that can be manually called that purges all elements from the Viz Rundown


* **Other information**:
