### PR TITLE
Fix bug: casparcg retries

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/casparCG/__tests__/casparcg.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/__tests__/casparcg.spec.ts
@@ -1594,32 +1594,9 @@ describe('CasparCG', () => {
 		})
 
 		// apply command to internal ccg-state
+		const resCommand = getMockCall(commandReceiver0, 1, 1)
 		// @ts-ignore
-		const currentState = await device.getState(mockTime.getCurrentTime())
-		const resCommand = getMockCall(commandReceiver0, 1, 1)._objectParams
-		if (currentState) {
-			// @ts-ignore
-			const currentCasparState = currentState.state
-
-			// @ts-ignore
-			const trackedState = await (await device._ccgState).getState()
-
-			const channel = currentCasparState.channels[resCommand.channel]
-			if (channel) {
-				if (!trackedState.channels[resCommand.channel]) {
-					trackedState.channels[resCommand.channel] = {
-						channelNo: channel.channelNo,
-						fps: channel.fps || 0,
-						videoMode: channel.videoMode || null,
-						layers: {},
-					}
-				}
-				// Copy the tracked from current state:
-				trackedState.channels[resCommand.channel].layers[resCommand.layer] = channel.layers[resCommand.layer]
-				// @ts-ignore
-				await (await device._ccgState).setState(trackedState)
-			}
-		}
+		await device._changeTrackedStateFromCommand(resCommand, mockTime.getCurrentTime())
 		// trigger retry mechanism
 		await (device as any)._assertIntendedState()
 		await mockTime.advanceTimeToTicks(10900)
@@ -1739,31 +1716,9 @@ describe('CasparCG', () => {
 
 		// apply command to internal ccg-state
 		// @ts-ignore
-		const currentState = await device.getState(mockTime.getCurrentTime())
-		const resCommand = getMockCall(commandReceiver0, 0, 1)._objectParams
-		if (currentState) {
-			// @ts-ignore
-			const currentCasparState = currentState.state
-
-			// @ts-ignore
-			const trackedState = await (await device._ccgState).getState()
-
-			const channel = currentCasparState.channels[resCommand.channel]
-			if (channel) {
-				if (!trackedState.channels[resCommand.channel]) {
-					trackedState.channels[resCommand.channel] = {
-						channelNo: channel.channelNo,
-						fps: channel.fps || 0,
-						videoMode: channel.videoMode || null,
-						layers: {},
-					}
-				}
-				// Copy the tracked from current state:
-				trackedState.channels[resCommand.channel].layers[resCommand.layer] = channel.layers[resCommand.layer]
-				// @ts-ignore
-				await (await device._ccgState).setState(trackedState)
-			}
-		}
+		const resCommand = getMockCall(commandReceiver0, 0, 1)
+		// @ts-ignore
+		await device._changeTrackedStateFromCommand(resCommand, mockTime.getCurrentTime())
 
 		// advance before half way
 		await mockTime.advanceTimeToTicks(10500)

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -936,7 +936,7 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 						// auto next + stop means bg -> fg => nextUp cleared
 						trackedState.channels[resCommand.channel].layers[resCommand.layer] = {
 							...channel.layers[resCommand.layer],
-							nextUp: undefined, // a play command always clears nextUp
+							nextUp: undefined, // auto next + stop means bg -> fg => nextUp cleared
 						}
 					} else if (resCommand.name === 'ResumeCommand' || resCommand.name === 'StopCommand') {
 						// stop and resume can be done without affecting nextup

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -47,6 +47,7 @@ import * as request from 'request'
 import { InternalTransitionHandler } from '../../devices/transitions/transitionHandler'
 import Debug from 'debug'
 import { endTrace, startTrace } from '../../lib'
+import { InternalState } from 'casparcg-state/dist/lib/stateObjectStorage'
 const debug = Debug('timeline-state-resolver:casparcg')
 
 const MAX_TIMESYNC_TRIES = 5
@@ -70,7 +71,6 @@ export type CommandReceiver = (
  */
 export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCGInternal> {
 	private _ccg: CasparCG
-	private _ccgState: CasparCGState
 	private _queue: { [token: string]: { time: number; command: CommandNS.IAMCPCommand } } = {}
 	private _commandReceiver: CommandReceiver
 	private _timeToTimecodeMap: { time: number; timecode: number } = { time: 0, timecode: 0 }
@@ -83,6 +83,7 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 	private _transitionHandler: InternalTransitionHandler = new InternalTransitionHandler()
 	private _retryTimeout: NodeJS.Timeout
 	private _retryTime: number | null = null
+	private _currentState: InternalState = { channels: {} }
 
 	constructor(deviceId: string, deviceOptions: DeviceOptionsCasparCGInternal, getCurrentTime: () => Promise<number>) {
 		super(deviceId, deviceOptions, getCurrentTime)
@@ -94,7 +95,6 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			if (deviceOptions.options.timeBase) this._timeBase = deviceOptions.options.timeBase
 		}
 
-		this._ccgState = new CasparCGState()
 		this._doOnTime = new DoOnTime(
 			() => {
 				return this.getCurrentTime()
@@ -130,23 +130,21 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 				// a "virgin server" was just restarted (so it is cleared & black).
 				// Otherwise it was probably just a loss of connection
 
-				this._ccgState.softClearState()
+				this._currentState = { channels: {} }
 				this.clearStates()
 				this.emit('resetResolver')
 			}
 		})
 
 		const command = await this._ccg.info()
-		this._ccgState.initStateFromChannelInfo(
-			_.map(command.response.data, (obj: any) => {
-				return {
-					channelNo: obj.channel,
-					videoMode: obj.format.toUpperCase(),
-					fps: obj.frameRate,
-				}
-			}) as ChannelInfo[],
-			this.getCurrentTime()
-		)
+		command.response.data.forEach((obj, i) => {
+			this._currentState.channels[i + 1] = {
+				channelNo: i + 1,
+				videoMode: obj.format.toUpperCase(),
+				fps: obj.frameRate,
+				layers: {},
+			}
+		})
 
 		if (typeof initOptions.retryInterval === 'number' && initOptions.retryInterval >= 0) {
 			this._retryTime = initOptions.retryInterval || MEDIA_RETRY_INTERVAL
@@ -190,11 +188,6 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 	 */
 	handleState(newState: TimelineState, newMappings: Mappings) {
 		super.onHandleState(newState, newMappings)
-		// check if initialized:
-		if (!this._ccgState.isInitialised) {
-			this.emit('warning', 'CasparCG State not initialized yet')
-			return
-		}
 
 		const previousStateTime = Math.max(this.getCurrentTime(), newState.time)
 
@@ -698,11 +691,6 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			}
 		}
 
-		if (!this._ccgState.isInitialised) {
-			statusCode = StatusCode.BAD
-			messages.push(`CasparCG device connection not initialized (restart required)`)
-		}
-
 		if (this._queueOverflow) {
 			statusCode = StatusCode.BAD
 			messages.push('Command queue overflow: CasparCG server has to be restarted')
@@ -871,7 +859,7 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 					if (currentState) {
 						const currentCasparState = currentState.state
 
-						const trackedState = this._ccgState.getState()
+						const trackedState = this._currentState
 
 						const channel = currentCasparState.channels[resCommand.channel]
 						if (channel) {
@@ -883,9 +871,53 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 									layers: {},
 								}
 							}
-							// Copy the tracked from current state:
-							trackedState.channels[resCommand.channel].layers[resCommand.layer] = channel.layers[resCommand.layer]
-							this._ccgState.setState(trackedState)
+
+							// copy into the trackedState
+							if (
+								(resCommand.name === 'PlayCommand' && resCommand.getParam('clip')) ||
+								(!resCommand.getParam('clip') &&
+									trackedState.channels[resCommand.channel].layers[resCommand.layer].nextUp)
+							) {
+								console.log(
+									resCommand.name === 'PlayCommand' && resCommand.getParam('clip'),
+									!resCommand.getParam('clip') &&
+										trackedState.channels[resCommand.channel].layers[resCommand.layer].nextUp
+								)
+								// a play command without parameters (channel/layer) is only succesful if the nextUp worked
+								// a play command with params can always be accepted
+								trackedState.channels[resCommand.channel].layers[resCommand.layer] = {
+									...channel.layers[resCommand.layer],
+									nextUp: undefined, // a play command always clears nextUp
+								}
+							} else if (resCommand.name === 'LoadbgCommand') {
+								// only loadbg can set nextUp and nextUp can only be set by loadbg
+								trackedState.channels[resCommand.channel].layers[resCommand.layer] = {
+									...trackedState.channels[resCommand.channel].layers[resCommand.layer],
+									nextUp: channel.layers[resCommand.layer].nextUp,
+								}
+							} else if (
+								resCommand.name === 'StopCommand' &&
+								trackedState.channels[resCommand.channel].layers[resCommand.layer].nextUp?.auto
+							) {
+								// auto next + stop means bg -> fg => nextUp cleared
+								trackedState.channels[resCommand.channel].layers[resCommand.layer] = {
+									...channel.layers[resCommand.layer],
+									nextUp: undefined, // a play command always clears nextUp
+								}
+							} else if (resCommand.name === 'ResumeCommand' || resCommand.name === 'StopCommand') {
+								// stop and resume can be done without affecting nextup
+								trackedState.channels[resCommand.channel].layers[resCommand.layer] = {
+									...channel.layers[resCommand.layer],
+									nextUp: trackedState.channels[resCommand.channel].layers[resCommand.layer].nextUp,
+								}
+							} else {
+								// anything else can always be copied but also clears nextUp
+								// @todo - can LOADBG be followed by an empty LOAD? (if yes, apply same logic as PLAY)
+								trackedState.channels[resCommand.channel].layers[resCommand.layer] = {
+									...channel.layers[resCommand.layer],
+									nextUp: undefined,
+								}
+							}
 						}
 					}
 				}
@@ -944,7 +976,7 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 
 		const ccgState = tlState.state
 
-		const diff = this._ccgState.getDiff(ccgState, this.getCurrentTime())
+		const diff = CasparCGState.diffStates(this._currentState, ccgState, this.getCurrentTime())
 
 		const cmd: Array<AMCPCommandVOWithContext> = []
 		for (const layer of diff) {


### PR DESCRIPTION
**Bug report:** retries of loadbg commands even when the command was succesful

**Issue found:** CasparCG state storage uses fast-clone for it's state storage, this does not respect classes (they convert to objects) therefore the diff mechanism was triggered.
**Additional issues found:** A successful play command without parameters could stop the retry logic from further executing because the entire state of that layer would be copied into the tracked state

**Solutions:** 

- Move away from the casparcg-state provided state storage to an internal storage object. We do shallow copies but with careful modifications this should not cause any issues.
- Decision branch for whether copying the intended state into the tracked state is correct depending on the executed command