### PR TITLE
Fix: http get requests

### DIFF
--- a/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -32,6 +32,7 @@ Array [
   "TimelineContentTypeAtem",
   "TimelineContentTypeCasparCg",
   "TimelineContentTypeHTTP",
+  "TimelineContentTypeHTTPParamType",
   "TimelineContentTypeHyperdeck",
   "TimelineContentTypeLawo",
   "TimelineContentTypeOBS",

--- a/packages/timeline-state-resolver-types/src/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/httpSend.ts
@@ -9,6 +9,8 @@ export interface HTTPSendCommandContent {
 	type: TimelineContentTypeHTTP
 	url: string
 	params: { [key: string]: number | string | any }
+	/** How the params are sent. Ignored for GET since params are sent in querystring. Default is JSON. */
+	paramsType?: TimelineContentTypeHTTPParamType
 	temporalPriority?: number // default: 0
 	/** Commands in the same queue will be sent in order (will wait for the previous to finish before sending next */
 	queueId?: string
@@ -27,6 +29,10 @@ export enum TimelineContentTypeHTTP {
 	POST = 'post',
 	PUT = 'put',
 	DELETE = 'delete',
+}
+export enum TimelineContentTypeHTTPParamType {
+	JSON = 'json',
+	FORM = 'form',
 }
 
 export type TimelineObjHTTPSendAny = TimelineObjHTTPRequest

--- a/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -44,6 +44,7 @@ Array [
   "TimelineContentTypeAtem",
   "TimelineContentTypeCasparCg",
   "TimelineContentTypeHTTP",
+  "TimelineContentTypeHTTPParamType",
   "TimelineContentTypeHyperdeck",
   "TimelineContentTypeLawo",
   "TimelineContentTypeOBS",

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -6,9 +6,10 @@ import {
 	HTTPSendCommandContent,
 	DeviceOptionsHTTPSend,
 	Mappings,
+	TimelineContentTypeHTTP,
 } from 'timeline-state-resolver-types'
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
-import got, { RequestError } from 'got'
+import got, { OptionsOfTextResponseBody, RequestError } from 'got'
 
 import { TimelineState, ResolvedTimelineObjectInstance } from 'superfly-timeline'
 
@@ -255,9 +256,19 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 
 		const httpReq = got[cmd.type]
 		try {
-			const response = await httpReq(cmd.url, {
-				json: 'params' in cmd ? cmd.params : undefined,
-			})
+
+			const options: OptionsOfTextResponseBody = {}
+
+			const params = 'params' in cmd && !_.isEmpty(cmd.params) ? cmd.params : undefined
+			if (params) {
+				if (cmd.type === TimelineContentTypeHTTP.GET) {
+					options.searchParams = params
+				} else {
+					options.json = params
+				}
+			}
+
+			const response = await httpReq(cmd.url, options)
 
 			if (response.statusCode === 200) {
 				this.emitDebug(

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -7,6 +7,7 @@ import {
 	DeviceOptionsHTTPSend,
 	Mappings,
 	TimelineContentTypeHTTP,
+	TimelineContentTypeHTTPParamType
 } from 'timeline-state-resolver-types'
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
 import got, { OptionsOfTextResponseBody, RequestError } from 'got'
@@ -264,7 +265,13 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 				if (cmd.type === TimelineContentTypeHTTP.GET) {
 					options.searchParams = params
 				} else {
-					options.json = params
+					if (cmd.paramsType === TimelineContentTypeHTTPParamType.FORM) {
+						options.form = params
+					} else {
+						// Default is json:
+						options.json = params
+					}
+
 				}
 			}
 

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -7,7 +7,7 @@ import {
 	DeviceOptionsHTTPSend,
 	Mappings,
 	TimelineContentTypeHTTP,
-	TimelineContentTypeHTTPParamType
+	TimelineContentTypeHTTPParamType,
 } from 'timeline-state-resolver-types'
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
 import got, { OptionsOfTextResponseBody, RequestError } from 'got'
@@ -257,7 +257,6 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 
 		const httpReq = got[cmd.type]
 		try {
-
 			const options: OptionsOfTextResponseBody = {}
 
 			const params = 'params' in cmd && !_.isEmpty(cmd.params) ? cmd.params : undefined
@@ -271,7 +270,6 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 						// Default is json:
 						options.json = params
 					}
-
 				}
 			}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

HTTPSend device didn't send GET requests at all


* **What is the new behavior (if this is a feature change)?**

HTTPSend now sends GET requests.

User can also choose how the `body` is sent ("json" or "form" type) for POST/PUT/etc requests.
  ref: https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#json


* **Other information**:

I've tested this to work, using quickTSR and a local http-server.
This should be backwards-compatible as it doesn't change the default way data is sent for POST/PUT/etc.
