### PR TITLE
Add support for Node18

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         lib-name: [timeline-state-resolver, timeline-state-resolver-types]
 
     steps:

--- a/packages/timeline-state-resolver-types/package.json
+++ b/packages/timeline-state-resolver-types/package.json
@@ -61,7 +61,7 @@
 		"precommit": "lint-staged"
 	},
 	"engines": {
-		"node": "^14.18 || ^16.14"
+		"node": "^14.18 || ^16.14 || 18"
 	},
 	"files": [
 		"/dist",

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -66,7 +66,7 @@
 		"precommit": "lint-staged"
 	},
 	"engines": {
-		"node": "^14.18 || ^16.14"
+		"node": "^14.18 || ^16.14 || 18"
 	},
 	"files": [
 		"/dist",


### PR DESCRIPTION
This PR adds support for Node v18 in CI and in "engines" in package.js.

Since it was such a small change, I thought that we could just add it right away.

FYI: I did the same in threadedclass, and[ it seems to work without a hitch](https://github.com/nytamin/threadedClass/actions/runs/3479117410), so that should be good too for v18.