### PR TITLE
feat: Emit debug state information

### DIFF
--- a/packages/timeline-state-resolver-types/src/device.ts
+++ b/packages/timeline-state-resolver-types/src/device.ts
@@ -44,6 +44,7 @@ export interface DeviceOptionsBase<T> extends SlowReportOptions {
 	disable?: boolean
 	options?: T
 	debug?: boolean
+	debugState?: boolean
 }
 
 export interface SlowReportOptions {

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -125,6 +125,7 @@ export interface StatReport {
 export type ConductorEvents = {
 	error: [...args: any[]]
 	debug: [...args: any[]]
+	debugState: [...args: any[]]
 	info: [...args: any[]]
 	warning: [...args: any[]]
 
@@ -368,11 +369,15 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 			const onDeviceDebug = (...args: DeviceEvents['debug']) => {
 				this.emit('debug', instanceId, ...args)
 			}
+			const onDeviceDebugState = (...args: DeviceEvents['debugState']) => {
+				this.emit('debugState', args)
+			}
 
 			newDevice.device.on('info', onDeviceInfo).catch(console.error)
 			newDevice.device.on('warning', onDeviceWarning).catch(console.error)
 			newDevice.device.on('error', onDeviceError).catch(console.error)
 			newDevice.device.on('debug', onDeviceDebug).catch(console.error)
+			newDevice.device.on('debugState', onDeviceDebugState).catch(console.error)
 
 			const device = await this.initDevice(deviceId, deviceOptions, activeRundownPlaylistId)
 
@@ -381,6 +386,7 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 			newDevice.device.removeListener('warning', onDeviceWarning).catch(console.error)
 			newDevice.device.removeListener('error', onDeviceError).catch(console.error)
 			newDevice.device.removeListener('debug', onDeviceDebug).catch(console.error)
+			newDevice.device.removeListener('debugState', onDeviceDebugState).catch(console.error)
 
 			return device
 		} catch (e) {

--- a/packages/timeline-state-resolver/src/devices/device.ts
+++ b/packages/timeline-state-resolver/src/devices/device.ts
@@ -48,6 +48,7 @@ export type DeviceEvents = {
 	warning: [warning: string]
 	error: [context: string, err: Error]
 	debug: [...debug: any[]]
+	debugState: [state: object]
 	/** The connection status has changed */
 	connectionChanged: [status: DeviceStatus]
 	/** A message to the resolver that something has happened that warrants a reset of the resolver (to re-run it again) */
@@ -116,12 +117,14 @@ export abstract class Device<TOptions extends DeviceOptionsBase<any>>
 	protected _reportAllCommands = false
 	protected _isActive = true
 	private debugLogging: boolean
+	private debugState: boolean
 
 	constructor(deviceId: string, deviceOptions: TOptions, getCurrentTime: () => Promise<number>) {
 		super()
 		this._deviceId = deviceId
 		this._deviceOptions = deviceOptions
 		this.debugLogging = deviceOptions.debug ?? true // Default to true to keep backwards compatibility
+		this.debugState = deviceOptions.debugState ?? false
 
 		this._instanceId = Math.floor(Math.random() * 10000)
 		this._startTime = Date.now()
@@ -213,6 +216,16 @@ export abstract class Device<TOptions extends DeviceOptionsBase<any>>
 	protected emitDebug(...args: any[]) {
 		if (this.debugLogging) {
 			this.emit('debug', ...args)
+		}
+	}
+
+	setDebugState(debug: boolean) {
+		this.debugState = debug
+	}
+
+	protected emitDebugState(state: object) {
+		if (this.debugState) {
+			this.emit('debugState', state)
 		}
 	}
 

--- a/packages/timeline-state-resolver/src/devices/deviceContainer.ts
+++ b/packages/timeline-state-resolver/src/devices/deviceContainer.ts
@@ -24,6 +24,7 @@ export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> extends Ev
 	private _startTime = -1
 	private _onEventListeners: { stop: () => void }[] = []
 	private _debugLogging = true
+	private _debugState = false
 	private _initialized = false
 
 	private constructor(deviceOptions: TOptions, threadConfig?: ThreadedClassConfig) {
@@ -108,6 +109,11 @@ export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> extends Ev
 		await this._device.setDebugLogging(debug)
 	}
 
+	public async setDebugState(debug: boolean): Promise<void> {
+		this._debugState = debug
+		await this._device.setDebugState(debug)
+	}
+
 	public get device(): ThreadedClass<Device<TOptions>> {
 		return this._device
 	}
@@ -135,5 +141,9 @@ export class DeviceContainer<TOptions extends DeviceOptionsBase<any>> extends Ev
 
 	public get debugLogging(): boolean {
 		return this._debugLogging
+	}
+
+	public get debugState(): boolean {
+		return this._debugState
 	}
 }

--- a/packages/timeline-state-resolver/src/integrations/abstract/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/abstract/index.ts
@@ -101,6 +101,19 @@ export class AbstractDevice extends DeviceWithState<AbstractState, DeviceOptions
 
 		// store the new state, for later use:
 		this.setState(newState, newState.time)
+
+		if (this.deviceOptions.debugState) {
+			const debugState: Record<string, object> = {}
+			for (const layer of Object.keys(newMappings)) {
+				const tlObject = newAbstractState.layers[layer]
+				if (tlObject !== undefined) {
+					debugState[layer] = { id: tlObject.id, classes: tlObject.classes, content: tlObject.content }
+				} else {
+					debugState[layer] = {}
+				}
+			}
+			this.emitDebugState(debugState)
+		}
 	}
 	/**
 	 * Clear any scheduled commands after this time


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the ability for devices to emit debug information that reflects their internal state.
See [this PR against core](https://github.com/nrkno/sofie-core/pull/823) for full feature description.

**What is the current behavior?** (You can also link to an open issue here)
New feature.


**What is the new behavior (if this is a feature change)?**
- Adds events and settings for emitting debug state information.
- Adds the ability to emit debug state to the Abstract device, if the sub-device has state debugging enabled.


**Other information**:
This PR has been opened by SuperFly.tv on behalf of EVS Broadcast Equipment.