### PR TITLE
feat(vmix): add support for starting and stopping VB.NET scripts

### DIFF
--- a/packages/timeline-state-resolver-types/src/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/vmix.ts
@@ -13,6 +13,7 @@ export type MappingVMixAny =
 	| MappingVMixExternal
 	| MappingVMixFadeToBlack
 	| MappingVMixFader
+	| MappingVMixScript
 
 export interface MappingVMix extends Mapping {
 	device: DeviceType.VMIX
@@ -88,6 +89,10 @@ export interface MappingVMixFader extends MappingVMix {
 	mappingType: MappingVMixType.Fader // should this have a separate mapping?
 }
 
+export interface MappingVMixScript extends MappingVMix {
+	mappingType: MappingVMixType.Script
+}
+
 export enum MappingVMixType {
 	Program = 0,
 	Preview = 1,
@@ -100,6 +105,7 @@ export enum MappingVMixType {
 	External = 8,
 	FadeToBlack = 9,
 	Fader = 10,
+	Script = 11,
 }
 
 export interface VMixOptions {
@@ -142,6 +148,9 @@ export enum VMixCommand {
 	OVERLAY_INPUT_IN = 'OVERLAY_INPUT_IN',
 	OVERLAY_INPUT_OUT = 'OVERLAY_INPUT_OUT',
 	SET_INPUT_OVERLAY = 'SET_INPUT_OVERLAY',
+	SCRIPT_START = 'SCRIPT_START',
+	SCRIPT_STOP = 'SCRIPT_STOP',
+	SCRIPT_STOP_ALL = 'SCRIPT_STOP_ALL',
 }
 
 export type TimelineContentVMixAny =
@@ -156,6 +165,7 @@ export type TimelineContentVMixAny =
 	| TimelineContentVMixOutput
 	| TimelineContentVMixOverlay
 	| TimelineContentVMixInput
+	| TimelineContentVMixScript
 
 export enum TimelineContentTypeVMix {
 	PROGRAM = 'PROGRAM',
@@ -169,6 +179,7 @@ export enum TimelineContentTypeVMix {
 	OUTPUT = 'OUTPUT',
 	EXTERNAL = 'EXTERNAL',
 	OVERLAY = 'OVERLAY',
+	SCRIPT = 'SCRIPT',
 }
 export interface TimelineContentVMixBase {
 	deviceType: DeviceType.VMIX
@@ -291,6 +302,13 @@ export interface TimelineContentVMixOverlay extends TimelineContentVMixBase {
 
 	/** Input number or name */
 	input: number | string
+}
+
+export interface TimelineContentVMixScript extends TimelineContentVMixBase {
+	type: TimelineContentTypeVMix.SCRIPT
+
+	/** Script name */
+	name: string
 }
 
 export interface VMixTransform {

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
@@ -18,6 +18,7 @@ import {
 	MappingVMixInput,
 	MappingVMixFadeToBlack,
 	MappingVMixFader,
+	MappingVMixScript,
 } from 'timeline-state-resolver-types'
 import { ThreadedClass } from 'threadedclass'
 import { VMixDevice } from '..'
@@ -2615,6 +2616,230 @@ describe('vMix', () => {
 		expect(onFunction).toHaveBeenCalledTimes(1)
 
 		expect(onFunction).toHaveBeenNthCalledWith(1, 'SetFader', expect.stringContaining('Value=0'))
+
+		clearMocks()
+		commandReceiver0.mockClear()
+
+		await myConductor.destroy()
+
+		expect(errorHandler).toHaveBeenCalledTimes(0)
+		expect(deviceErrorHandler).toHaveBeenCalledTimes(0)
+	})
+
+	test('Script Start', async () => {
+		let device: any = undefined
+		const commandReceiver0 = jest.fn((...args) => {
+			// pipe through the command
+			return device._defaultCommandReceiver(...args)
+		})
+
+		const myLayerMapping0: MappingVMixScript = {
+			device: DeviceType.VMIX,
+			mappingType: MappingVMixType.Script,
+			deviceId: 'myvmix',
+		}
+		const myLayerMapping: Mappings = {
+			vmix_ss0: myLayerMapping0,
+		}
+
+		const myConductor = new Conductor({
+			multiThreadedResolver: false,
+			getCurrentTime: mockTime.getCurrentTime,
+		})
+		const errorHandler = jest.fn((...args) => console.log('Error in device', ...args))
+		myConductor.on('error', errorHandler)
+
+		await myConductor.init()
+
+		await runPromise(
+			myConductor.addDevice('myvmix', {
+				type: DeviceType.VMIX,
+				options: {
+					host: '127.0.0.1',
+					port: 9999,
+				},
+				commandReceiver: commandReceiver0,
+			}),
+			mockTime
+		)
+
+		const deviceContainer = myConductor.getDevice('myvmix')
+		device = deviceContainer!.device as ThreadedClass<VMixDevice>
+		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
+		device.on('error', deviceErrorHandler)
+		device.on('commandError', deviceErrorHandler)
+
+		myConductor.setTimelineAndMappings([], myLayerMapping)
+
+		expect(mockTime.getCurrentTime()).toEqual(10050)
+		await mockTime.advanceTimeToTicks(10100)
+
+		// get initial info
+		expect(onXML).toHaveBeenCalledTimes(1)
+
+		clearMocks()
+		commandReceiver0.mockClear()
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+
+		myConductor.setTimelineAndMappings([
+			{
+				id: 'ss0',
+				enable: {
+					start: 11000,
+					duration: 5000,
+				},
+				layer: 'vmix_ss0',
+				content: {
+					deviceType: DeviceType.VMIX,
+					type: TimelineContentTypeVMix.SCRIPT,
+					name: 'myscript',
+				},
+			},
+		])
+
+		await mockTime.advanceTimeToTicks(11300)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(1)
+		expect(commandReceiver0).toHaveBeenNthCalledWith(
+			1,
+			11000,
+			expect.objectContaining({
+				command: {
+					command: VMixCommand.SCRIPT_START,
+					value: 'myscript',
+				},
+			}),
+			null,
+			expect.any(String)
+		)
+
+		expect(onFunction).toHaveBeenCalledTimes(1)
+
+		expect(onFunction).toHaveBeenNthCalledWith(1, 'ScriptStart', expect.stringContaining('Value=myscript'))
+
+		clearMocks()
+		commandReceiver0.mockClear()
+
+		await myConductor.destroy()
+
+		expect(errorHandler).toHaveBeenCalledTimes(0)
+		expect(deviceErrorHandler).toHaveBeenCalledTimes(0)
+	})
+
+	test('Script Stop', async () => {
+		let device: any = undefined
+		const commandReceiver0 = jest.fn((...args) => {
+			// pipe through the command
+			return device._defaultCommandReceiver(...args)
+		})
+
+		const myLayerMapping0: MappingVMixScript = {
+			device: DeviceType.VMIX,
+			mappingType: MappingVMixType.Script,
+			deviceId: 'myvmix',
+		}
+		const myLayerMapping: Mappings = {
+			vmix_ss0: myLayerMapping0,
+		}
+
+		const myConductor = new Conductor({
+			multiThreadedResolver: false,
+			getCurrentTime: mockTime.getCurrentTime,
+		})
+		const errorHandler = jest.fn((...args) => console.log('Error in device', ...args))
+		myConductor.on('error', errorHandler)
+
+		await myConductor.init()
+
+		await runPromise(
+			myConductor.addDevice('myvmix', {
+				type: DeviceType.VMIX,
+				options: {
+					host: '127.0.0.1',
+					port: 9999,
+				},
+				commandReceiver: commandReceiver0,
+			}),
+			mockTime
+		)
+
+		const deviceContainer = myConductor.getDevice('myvmix')
+		device = deviceContainer!.device as ThreadedClass<VMixDevice>
+		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
+		device.on('error', deviceErrorHandler)
+		device.on('commandError', deviceErrorHandler)
+
+		myConductor.setTimelineAndMappings([], myLayerMapping)
+
+		expect(mockTime.getCurrentTime()).toEqual(10050)
+		await mockTime.advanceTimeToTicks(10100)
+
+		// get initial info
+		expect(onXML).toHaveBeenCalledTimes(1)
+
+		clearMocks()
+		commandReceiver0.mockClear()
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+
+		myConductor.setTimelineAndMappings([
+			{
+				id: 'ss0',
+				enable: {
+					start: 11000,
+					duration: 5000,
+				},
+				layer: 'vmix_ss0',
+				content: {
+					deviceType: DeviceType.VMIX,
+					type: TimelineContentTypeVMix.SCRIPT,
+					name: 'myscript',
+				},
+			},
+		])
+
+		await mockTime.advanceTimeToTicks(11300)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(1)
+		expect(commandReceiver0).toHaveBeenNthCalledWith(
+			1,
+			11000,
+			expect.objectContaining({
+				command: {
+					command: VMixCommand.SCRIPT_START,
+					value: 'myscript',
+				},
+			}),
+			null,
+			expect.any(String)
+		)
+
+		expect(onFunction).toHaveBeenCalledTimes(1)
+
+		expect(onFunction).toHaveBeenNthCalledWith(1, 'ScriptStart', expect.stringContaining('Value=myscript'))
+
+		await mockTime.advanceTimeToTicks(20000)
+
+		expect(commandReceiver0).toHaveBeenCalledTimes(2)
+		expect(commandReceiver0).toHaveBeenNthCalledWith(
+			2,
+			16000,
+			expect.objectContaining({
+				command: {
+					command: VMixCommand.SCRIPT_STOP,
+					value: 'myscript',
+				},
+			}),
+			null,
+			expect.any(String)
+		)
+
+		expect(onFunction).toHaveBeenCalledTimes(2)
+
+		expect(onFunction).toHaveBeenNthCalledWith(2, 'ScriptStop', expect.stringContaining('Value=myscript'))
 
 		clearMocks()
 		commandReceiver0.mockClear()

--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -280,6 +280,12 @@ export class VMix extends BaseConnection {
 				return this.overlayInputOut(command.value)
 			case VMixCommand.SET_INPUT_OVERLAY:
 				return this.setInputOverlay(command.input, command.index, command.value)
+			case VMixCommand.SCRIPT_START:
+				return this.scriptStart(command.value)
+			case VMixCommand.SCRIPT_STOP:
+				return this.scriptStop(command.value)
+			case VMixCommand.SCRIPT_STOP_ALL:
+				return this.scriptStopAll()
 			default:
 				throw new Error(`vmixAPI: Command ${((command || {}) as any).command} not implemented`)
 		}
@@ -507,6 +513,18 @@ export class VMix extends BaseConnection {
 		const val = `${index},${value}`
 		return this.sendCommandFunction(`SetMultiViewOverlay`, { input, value: val })
 	}
+
+	public async scriptStart(value: string): Promise<any> {
+		return this.sendCommandFunction(`ScriptStart`, { value })
+	}
+
+	public async scriptStop(value: string): Promise<any> {
+		return this.sendCommandFunction(`ScriptStop`, { value })
+	}
+
+	public async scriptStopAll(): Promise<any> {
+		return this.sendCommandFunction(`ScriptStopAll`, {})
+	}
 }
 
 export interface VMixStateCommandBase {
@@ -661,6 +679,17 @@ export interface VMixStateCommandSetInputOverlay extends VMixStateCommandBase {
 	index: number
 	value: string | number
 }
+export interface VMixStateCommandScriptStart extends VMixStateCommandBase {
+	command: VMixCommand.SCRIPT_START
+	value: string
+}
+export interface VMixStateCommandScriptStop extends VMixStateCommandBase {
+	command: VMixCommand.SCRIPT_STOP
+	value: string
+}
+export interface VMixStateCommandScriptStopAll extends VMixStateCommandBase {
+	command: VMixCommand.SCRIPT_STOP_ALL
+}
 export type VMixStateCommand =
 	| VMixStateCommandPreviewInput
 	| VMixStateCommandTransition
@@ -696,3 +725,6 @@ export type VMixStateCommand =
 	| VMixStateCommandOverlayInputIn
 	| VMixStateCommandOverlayInputOut
 	| VMixStateCommandSetInputOverlay
+	| VMixStateCommandScriptStart
+	| VMixStateCommandScriptStop
+	| VMixStateCommandScriptStopAll

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -197,7 +197,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 				Fullscreen2: { source: 'Program' },
 			},
 			inputLayers: {},
-			desiredScripts: [],
+			runningScripts: [],
 		}
 	}
 
@@ -387,7 +387,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						break
 					case MappingVMixType.Script:
 						if (content.type === TimelineContentTypeVMix.SCRIPT) {
-							deviceState.desiredScripts.push(content.name)
+							deviceState.runningScripts.push(content.name)
 						}
 						break
 				}
@@ -971,8 +971,8 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 		newVMixState: VMixStateExtended
 	): Array<VMixStateCommandWithContext> {
 		const commands: Array<VMixStateCommandWithContext> = []
-		_.map(newVMixState.desiredScripts, (name) => {
-			const alreadyRunning = oldVMixState.desiredScripts.includes(name)
+		_.map(newVMixState.runningScripts, (name) => {
+			const alreadyRunning = oldVMixState.runningScripts.includes(name)
 			if (!alreadyRunning) {
 				commands.push({
 					command: {
@@ -984,8 +984,8 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 				})
 			}
 		})
-		_.map(oldVMixState.desiredScripts, (name) => {
-			const noLongerDesired = !newVMixState.desiredScripts.includes(name)
+		_.map(oldVMixState.runningScripts, (name) => {
+			const noLongerDesired = !newVMixState.runningScripts.includes(name)
 			if (noLongerDesired) {
 				commands.push({
 					command: {
@@ -1056,7 +1056,7 @@ export interface VMixStateExtended {
 		Fullscreen2: VMixOutput
 	}
 	inputLayers: { [key: string]: string }
-	desiredScripts: string[]
+	runningScripts: string[]
 }
 
 export interface VMixState {


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norway.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

vMix scripts cannot be started or stopped with TSR.

* **What is the new behavior (if this is a feature change)?**

vMix scripts can be invoked and cancelled now:

```ts
export const input: TSRInput = {
	timeline: [
		literal<TSRTimelineObj<TimelineContentVMixScript>>({
			id: 'script0',
			enable: {
				start: Date.now(),
				duration: 20 * 1000,
			},
			layer: 'vmixLayer0',
			content: {
				deviceType: DeviceType.VMIX,
				type: TimelineContentTypeVMix.SCRIPT,
				name: 'myscript',
			},
		}),
	],
}
```

* **Other information**:

Tested via quick-tsr by writing a short VB.NET script that just has two console writes with a sleep between them:
```vb
Console.WriteLine("I sleep...")
Sleep(5000)
Console.WriteLine("I wake!!!")
```
