### PR TITLE
Chore: Allow node14+ in tsr types

### DIFF
--- a/packages/timeline-state-resolver-types/package.json
+++ b/packages/timeline-state-resolver-types/package.json
@@ -61,7 +61,7 @@
 		"precommit": "lint-staged"
 	},
 	"engines": {
-		"node": "^14.18 || ^16.14 || 18"
+		"node": ">=14.18"
 	},
 	"files": [
 		"/dist",


### PR DESCRIPTION
This PR changes the allowed Node-versions in package.json file to allow all Node-versions above 14.18.

This applies only to **TSR-Types,** since that only exposes types and simpler code, which _should be fine_ to use in newer & future versions of Node.

My reasoning for this is that I think that we should not hold back other libraries by disallowing the use of newer versions of Node.

This PR is similar to  https://github.com/nrkno/sofie-core/pull/860
