### PR TITLE
fix: casparcg doesnt resync state after server restart

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -103,18 +103,64 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			this.makeReady(false) // always make sure timecode is correct, setting it can never do bad
 				.catch((e) => this.emit('error', 'casparCG.makeReady', e))
 
-			this._connected = true
-			this._connectionChanged()
+			Promise.resolve()
+				.then(async () => {
+					// a "virgin server" was just restarted (so it is cleared & black).
+					// Otherwise it was probably just a loss of connection
 
-			// TODO - maybe add this back based on info command
-			// if (event.valueOf().virginServer === true) {
-			// 	// a "virgin server" was just restarted (so it is cleared & black).
-			// 	// Otherwise it was probably just a loss of connection
+					const { error, request } = await this._ccg.executeCommand({ command: Commands.Info, params: {} })
+					if (error) return true
 
-			// 	this._currentState = { channels: {} }
-			// 	this.clearStates()
-			// 	this.emit('resetResolver')
-			// }
+					const response = await request
+
+					const channelPromises: Promise<Response>[] = []
+					const channelLength: number = response?.data?.['length'] ?? 0
+
+					// Issue commands
+					for (let i = 1; i <= channelLength; i++) {
+						// 1-based index for channels
+
+						const { error, request } = await this._ccg.executeCommand({
+							command: Commands.Info,
+							params: { channel: i },
+						})
+						if (error) {
+							// We can't return here, as that will leave anything in channelPromises as potentially unhandled
+							channelPromises.push(Promise.reject('execute failed'))
+							break
+						} else if (request) {
+							channelPromises.push(request)
+						}
+					}
+
+					// Wait for all commands
+					const channelResults = await Promise.all(channelPromises)
+
+					// Resync if all channels have no stage object (no possibility of anything playing)
+					return !channelResults.find((ch) => ch.data['stage'])
+				})
+				.catch((e) => {
+					this.emit('error', 'connect virgin check failed', e)
+					// Something failed, force the resync as glitching playback is better than black output
+					return true
+				})
+				.then((doResync) => {
+					// Finally we can report it as connected
+					this._connected = true
+					this._connectionChanged()
+
+					if (doResync) {
+						this._currentState = { channels: {} }
+						this.clearStates()
+						this.emit('resetResolver')
+					}
+				})
+				.catch((e) => {
+					this.emit('error', 'connect state resync failed', e)
+					// Some unknwon error occured, report the connection as failed
+					this._connected = false
+					this._connectionChanged()
+				})
 		})
 
 		this._ccg.on('disconnect', () => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

when casparcg server is restarted, tsr will not resync the state, so all channels will remain black and only play new content.

* **What is the new behavior (if this is a feature change)?**

Upon connection to casparcg, a basic check is performed to see if anything is playing on the server. If it is not then the state is resynced. Any failure in this check (eg timeout) causes it to be resynced, as having a glitch on air is better than the output remaining black.

* **Other information**:

Inspired by the code in older casparcg-connection that got removed in the overhaul https://github.com/SuperFlyTV/casparcg-connection/blob/v4.1.1/src/CasparCG.ts#L2151-L2182

For a while I was seeing timeouts at any command in this process, but that appears to have gone away, I can't explain why
