### PR TITLE
fix: properly parse multi-packet vMix TCP API responses

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -104,7 +104,12 @@ export class BaseConnection extends EventEmitter<ConnectionEvents> {
 
 			if (result && result.groups?.['response']) {
 				// create a response object
-				const responseLen = parseInt(result?.groups?.['response'])
+				// Add 2 to account for the space between `command` and `response` as well as the newline after `response`.
+				const responseHeaderLength = result.groups?.['command'].length + result.groups?.['response'].length + 2
+				if (Number.isNaN(responseHeaderLength)) {
+					break lineProcessing
+				}
+				const responseLen = parseInt(result?.groups?.['response']) - responseHeaderLength
 				const response: Response = {
 					command: result.groups?.['command'],
 					response: (Number.isNaN(responseLen) ? result.groups?.['response'] : 'OK') as Response['response'],


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norway.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

TSR fails to parse vMix TCP API responses which span multiple packets, due to a miscalculation of the response **body** length versus the response **header** length.

* **What is the new behavior (if this is a feature change)?**

When checking to see if a response **body** has fully come in, the response **header** length is subtracted from the expected length of the body.

* **Other information**:

Debugged and confirmed using `quick-tsr `🙆‍♂️ 
