### PR TITLE
fix: change `DeviceType.MULTI_OSC` value

### DIFF
--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -75,7 +75,7 @@ export enum DeviceType {
 	OBS = 21,
 	SOFIE_CHEF = 22,
 	TELEMETRICS = 23,
-	MULTI_OSC = 24,
+	MULTI_OSC = 25,
 }
 
 export type TSRTimelineKeyframe<TContent> = Timeline.TimelineKeyframe<TContent>


### PR DESCRIPTION
In https://github.com/nrkno/sofie-timeline-state-resolver/pull/243, there was a conflict with both `MULTI_OSC` and `TRICASTER` wanting to have the id of `24`.

To minimise impact, `MULTI_OSC` has been changed to 25, and we should do the same in R49 (the first release containing `MULTI_OSC`) to avoid `MULTI_OSC: 24` ever reaching a production deployment


* **Other information**:
