### PR TITLE
fix: Specify process ID for CasparCG restart - SOFIE-1646

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/casparCG.ts
+++ b/packages/timeline-state-resolver-types/src/generated/casparCG.ts
@@ -16,6 +16,7 @@ export interface CasparCGOptions {
 	port?: number
 	launcherHost?: string
 	launcherPort?: number
+	launcherProcess?: string
 	/**
 	 * fps used for all channels
 	 */

--- a/packages/timeline-state-resolver/src/integrations/casparCG/$schemas/options.json
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/$schemas/options.json
@@ -25,6 +25,11 @@
 			"ui:title": "Launcher Port",
 			"default": 8005
 		},
+		"launcherProcess": {
+			"type": "string",
+			"ui:title": "Launcher Process",
+			"default": "casparcg"
+		},
 		"fps": {
 			"type": "number",
 			"description": "fps used for all channels",

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -671,9 +671,12 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 		if (!this.initOptions.launcherPort) {
 			return { result: ActionExecutionResultCode.Error, response: t('CasparCGDevice: config.launcherPort is not set!') }
 		}
+		if (!this.initOptions.launcherProcess) {
+			return { result: ActionExecutionResultCode.Error, response: t('CasparCGDevice: config.launcherProcess is not set!') }
+		}
 
 		return new Promise<ActionExecutionResult>((resolve) => {
-			const url = `http://${this.initOptions?.launcherHost}:${this.initOptions?.launcherPort}/processes/casparcg/restart`
+			const url = `http://${this.initOptions?.launcherHost}:${this.initOptions?.launcherPort}/processes/${this.initOptions?.launcherProcess}/restart`
 			request.post(
 				url,
 				{}, // json: cmd.params

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -672,7 +672,10 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			return { result: ActionExecutionResultCode.Error, response: t('CasparCGDevice: config.launcherPort is not set!') }
 		}
 		if (!this.initOptions.launcherProcess) {
-			return { result: ActionExecutionResultCode.Error, response: t('CasparCGDevice: config.launcherProcess is not set!') }
+			return {
+				result: ActionExecutionResultCode.Error,
+				response: t('CasparCGDevice: config.launcherProcess is not set!'),
+			}
 		}
 
 		return new Promise<ActionExecutionResult>((resolve) => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Calling the `restart-caspar` action assumes that the launcher process ID is `casparcg` so will either fail or restart the wrong Caspar instance if this is not the case


* **What is the new behavior (if this is a feature change)?**
The launcher process ID can now be specified.


* **Other information**:
