### PR TITLE
feat: add restart command to vMix inputs

### DIFF
--- a/packages/timeline-state-resolver-types/src/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/vmix.ts
@@ -153,6 +153,7 @@ export enum VMixCommand {
 	SCRIPT_STOP_ALL = 'SCRIPT_STOP_ALL',
 	LIST_ADD = 'LIST_ADD',
 	LIST_REMOVE_ALL = 'LIST_REMOVE_ALL',
+	RESTART_INPUT = 'RESTART_INPUT',
 }
 
 export type TimelineContentVMixAny =
@@ -283,6 +284,9 @@ export interface TimelineContentVMixInput extends TimelineContentVMixBase {
 
 	/** An array of file paths to load into a List input. Uses Windows-style path separators (\\). Only applies to List inputs. */
 	listFilePaths?: string[]
+
+	/** If media should start from the beginning or resume from where it left off */
+	restart?: boolean
 }
 
 export interface TimelineContentVMixOutput extends TimelineContentVMixBase {

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
@@ -595,6 +595,7 @@ describe('vMix', () => {
 				content: {
 					deviceType: DeviceType.VMIX,
 					type: TimelineContentTypeVMix.INPUT,
+					restart: true,
 					loop: true,
 					playing: true,
 					overlays: {
@@ -611,7 +612,7 @@ describe('vMix', () => {
 			11000,
 			expect.objectContaining({
 				command: {
-					command: VMixCommand.LOOP_ON,
+					command: VMixCommand.RESTART_INPUT,
 					input: '2',
 				},
 			}),
@@ -620,6 +621,18 @@ describe('vMix', () => {
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
 			2,
+			11000,
+			expect.objectContaining({
+				command: {
+					command: VMixCommand.LOOP_ON,
+					input: '2',
+				},
+			}),
+			null,
+			expect.any(String)
+		)
+		expect(commandReceiver0).toHaveBeenNthCalledWith(
+			3,
 			11000,
 			expect.objectContaining({
 				command: {
@@ -633,7 +646,7 @@ describe('vMix', () => {
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
-			3,
+			4,
 			11000,
 			expect.objectContaining({
 				command: {
@@ -647,7 +660,7 @@ describe('vMix', () => {
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
-			4,
+			5,
 			11000,
 			expect.objectContaining({
 				command: {
@@ -659,16 +672,17 @@ describe('vMix', () => {
 			expect.any(String)
 		)
 
-		expect(onFunction).toHaveBeenCalledTimes(4)
+		expect(onFunction).toHaveBeenCalledTimes(5)
 
-		expect(onFunction).toHaveBeenNthCalledWith(1, 'LoopOn', expect.stringContaining('Input=2'))
+		expect(onFunction).toHaveBeenNthCalledWith(1, 'Restart', expect.stringContaining('Input=2'))
+		expect(onFunction).toHaveBeenNthCalledWith(2, 'LoopOn', expect.stringContaining('Input=2'))
 		expect(onFunction).toHaveBeenNthCalledWith(
-			2,
+			3,
 			'SetMultiViewOverlay',
 			expect.stringContaining('Input=2&Value=1,G:/videos/My Other Clip.mp4')
 		)
-		expect(onFunction).toHaveBeenNthCalledWith(3, 'SetMultiViewOverlay', expect.stringContaining('Input=2&Value=3,5'))
-		expect(onFunction).toHaveBeenNthCalledWith(4, 'Play', expect.stringContaining('Input=2'))
+		expect(onFunction).toHaveBeenNthCalledWith(4, 'SetMultiViewOverlay', expect.stringContaining('Input=2&Value=3,5'))
+		expect(onFunction).toHaveBeenNthCalledWith(5, 'Play', expect.stringContaining('Input=2'))
 
 		clearMocks()
 		commandReceiver0.mockClear()

--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -295,6 +295,8 @@ export class VMix extends BaseConnection {
 				return this.listAdd(command.input, command.value)
 			case VMixCommand.LIST_REMOVE_ALL:
 				return this.listRemoveAll(command.input)
+			case VMixCommand.RESTART_INPUT:
+				return this.restart(command.input)
 			default:
 				throw new Error(`vmixAPI: Command ${((command || {}) as any).command} not implemented`)
 		}
@@ -554,6 +556,10 @@ export class VMix extends BaseConnection {
 	public async listRemoveAll(input: string | number): Promise<any> {
 		return this.sendCommandFunction(`ListRemoveAll`, { input })
 	}
+
+	public async restart(input: string | number): Promise<any> {
+		return this.sendCommandFunction(`Restart`, { input })
+	}
 }
 
 export interface VMixStateCommandBase {
@@ -728,6 +734,10 @@ export interface VMixStateCommandListRemoveAll extends VMixStateCommandBase {
 	command: VMixCommand.LIST_REMOVE_ALL
 	input: string | number
 }
+export interface VMixStateCommandRestart extends VMixStateCommandBase {
+	command: VMixCommand.RESTART_INPUT
+	input: string | number
+}
 export type VMixStateCommand =
 	| VMixStateCommandPreviewInput
 	| VMixStateCommandTransition
@@ -768,3 +778,4 @@ export type VMixStateCommand =
 	| VMixStateCommandScriptStopAll
 	| VMixStateCommandListAdd
 	| VMixStateCommandListRemoveAll
+	| VMixStateCommandRestart

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -440,6 +440,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 									transform: content.transform,
 									overlays: content.overlays,
 									listFilePaths: content.listFilePaths,
+									restart: content.restart,
 								},
 
 								{ key: mapping.index || content.filePath },
@@ -719,6 +720,16 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.SET_POSITION,
 						input: key,
 						value: input.position ? input.position : 0,
+					},
+					context: null,
+					timelineId: '',
+				})
+			}
+			if (input.restart !== undefined && oldInput.restart !== input.restart && input.restart) {
+				commands.push({
+					command: {
+						command: VMixCommand.RESTART_INPUT,
+						input: key,
 					},
 					context: null,
 					timelineId: '',
@@ -1227,6 +1238,7 @@ export interface VMixInput {
 	transform?: VMixTransform
 	overlays?: VMixInputOverlays
 	listFilePaths?: string[]
+	restart?: boolean
 }
 
 export interface VMixOverlay {


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...

Feature

* **What is the current behavior?** (You can also link to an open issue here)

The input restart command is not supported in vMix.

* **What is the new behavior (if this is a feature change)?**

An optional `restart` property has been added to vMix input timeline objects, to restart whatever media might be present there.

* **Other information**:

I wasn't sure if I should PR this to R50 or R49.
