### PR TITLE
fix: wrap singular.live JSON commands in an array

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/singularLive/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/singularLive/index.ts
@@ -298,7 +298,7 @@ export class SingularLiveDevice extends DeviceWithState<SingularLiveState, Devic
 
 		return new Promise<void>((resolve, reject) => {
 			got
-				.patch(url, { json: cmd })
+				.patch(url, { json: [cmd] })
 				.then((response) => {
 					if (response.statusCode === 200) {
 						this.emitDebug(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Singular.live timeline objects do not work.

* **What is the new behavior (if this is a feature change)?**

Singular.live timeline objects work.

* **Other information**:
This is how the Singular.live API expects them to be formatted. This got accidentally removed when migrating away from `request`.