### PR TITLE
fix(PanasonicPTZ): clear ping interval on terminate

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/panasonicPTZ/__tests__/panasonicPTZ.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/panasonicPTZ/__tests__/panasonicPTZ.spec.ts
@@ -212,12 +212,12 @@ describe('Panasonic PTZ', () => {
 
 		expect(commandReceiver0).toHaveBeenCalledTimes(2)
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
-			type: TimelineContentTypePanasonicPtz.PRESET,
-			preset: 1,
-		})
-		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			type: TimelineContentTypePanasonicPtz.SPEED,
 			speed: 250,
+		})
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
+			type: TimelineContentTypePanasonicPtz.PRESET,
+			preset: 1,
 		})
 
 		await mockTime.advanceTimeToTicks(11000)

--- a/packages/timeline-state-resolver/src/integrations/panasonicPTZ/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/panasonicPTZ/index.ts
@@ -59,6 +59,14 @@ export interface PanasonicPtzCommandWithContext {
 type CommandContext = any
 
 const PROBE_INTERVAL = 10 * 1000 // Probe every 10s
+
+const COMMAND_PRIORITY: Record<PanasonicPtzCommand['type'], number> = {
+	presetSpeed: 0,
+	zoomSpeed: 1,
+	zoom: 2,
+	presetMem: 3,
+}
+
 /**
  * A wrapper for panasonic ptz cameras. Maps timeline states to device states and
  * executes commands to achieve such states. Depends on PanasonicPTZAPI class for
@@ -70,6 +78,7 @@ export class PanasonicPtzDevice extends DeviceWithState<PanasonicPtzState, Devic
 	private _connected = false
 
 	private _commandReceiver: CommandReceiver
+	private _pingInterval: NodeJS.Timer
 
 	constructor(
 		deviceId: string,
@@ -93,57 +102,69 @@ export class PanasonicPtzDevice extends DeviceWithState<PanasonicPtzState, Devic
 		)
 		this.handleDoOnTime(this._doOnTime, 'PanasonicPTZ')
 
-		if (deviceOptions.options && deviceOptions.options.host) {
-			// set up connection class
-			this._device = new PanasonicPtzHttpInterface(
-				deviceOptions.options.host,
-				deviceOptions.options.port,
-				deviceOptions.options.https
-			)
-			this._device.on('error', (msg) => {
-				if (msg.code === 'ECONNREFUSED') return // ignore, since we catch this in connection logic
-				this.emit('error', 'PanasonicPtzHttpInterface', msg)
-			})
-			this._device.on('disconnected', () => {
-				this._setConnected(false)
-			})
-			this._device.on('debug', (...args) => {
-				this.emitDebug('Panasonic PTZ', ...args)
-			})
-		} else {
+		if (!deviceOptions.options || !deviceOptions.options.host) {
 			this._device = undefined
+			return
 		}
+
+		// set up connection class
+		this._device = new PanasonicPtzHttpInterface(
+			deviceOptions.options.host,
+			deviceOptions.options.port,
+			deviceOptions.options.https
+		)
+		this._device.on('error', (msg) => {
+			if (msg.code === 'ECONNREFUSED') return // ignore, since we catch this in connection logic
+			this.emit('error', 'PanasonicPtzHttpInterface', msg)
+		})
+		this._device.on('disconnected', () => {
+			this._setConnected(false)
+		})
+		this._device.on('debug', (...args) => {
+			this.emitDebug('Panasonic PTZ', ...args)
+		})
 	}
 
 	/**
 	 * Initiates the device: set up ping for connection logic.
 	 */
 	async init(_initOptions: PanasonicPTZOptions): Promise<boolean> {
-		if (this._device) {
-			return new Promise((resolve, reject) => {
-				setInterval(() => {
-					this._device!.ping()
-						.then((result) => {
-							this._setConnected(!!result)
-						})
-						.catch(() => {
-							this._setConnected(false)
-						})
-				}, PROBE_INTERVAL)
+		if (!this._device) {
+			return Promise.reject('There are no cameras set up for this device')
+		}
 
-				this._device!.ping()
+		return new Promise((resolve, reject) => {
+			this._pingInterval = setInterval(() => {
+				if (!this._device) {
+					this.emit('error', `init() interval`, new Error(`Device handler for "${this.deviceId}" not defined`))
+					return
+				}
+
+				this._device
+					.ping()
 					.then((result) => {
 						this._setConnected(!!result)
+					})
+					.catch(() => {
+						this._setConnected(false)
+					})
+			}, PROBE_INTERVAL)
 
-						resolve(true)
-					})
-					.catch((e) => {
-						reject(e)
-					})
-			})
-		}
-		// @ts-ignore no-unused-vars
-		return Promise.reject('There are no cameras set up for this device')
+			if (!this._device) {
+				throw new Error(`Device handler for "${this.deviceId}" not defined`)
+			}
+
+			this._device
+				.ping()
+				.then((result) => {
+					this._setConnected(!!result)
+
+					resolve(true)
+				})
+				.catch((e) => {
+					reject(e)
+				})
+		})
 	}
 
 	/**
@@ -238,6 +259,7 @@ export class PanasonicPtzDevice extends DeviceWithState<PanasonicPtzState, Devic
 		this._doOnTime.clearQueueAfter(clearAfterTime)
 	}
 	async terminate() {
+		if (this._pingInterval) clearInterval(this._pingInterval)
 		if (this._device) {
 			this._device.dispose()
 		}
@@ -320,7 +342,11 @@ export class PanasonicPtzDevice extends DeviceWithState<PanasonicPtzState, Devic
 	 * Add commands to queue, to be executed at the right time
 	 */
 	private _addToQueue(commandsToAchieveState: Array<PanasonicPtzCommandWithContext>, time: number) {
-		_.each(commandsToAchieveState, (cmd: PanasonicPtzCommandWithContext) => {
+		const sortedCommandsToAchieveState = commandsToAchieveState.sort(
+			(a, b) => COMMAND_PRIORITY[a.command.type] - COMMAND_PRIORITY[b.command.type]
+		)
+
+		_.each(sortedCommandsToAchieveState, (cmd: PanasonicPtzCommandWithContext) => {
 			// add the new commands to the queue:
 			this._doOnTime.queue(
 				time,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Refactor/bugfix

* **What is the current behavior?** (You can also link to an open issue here)

The Panasonic PTZ integration sets up an interval to poll for device state. This interval is not cleared anywhere.
The commands to the Panasonic PTZ device are not sent in any particular order.

* **What is the new behavior (if this is a feature change)?**

A specific, predictable order is set for commands to be sent to the Panasonic device at the same time. Preset speed is sent first, then zoom speed, then zoom property, and then finally, preset memory recall.
The timeout is cleared on device termination.

* **Other information**:

This probably had no side-effects in production, but just was messy.
