### PR TITLE
feat(vMix): retry sending media load commands if the file wasn't found

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vmix.ts
@@ -8,6 +8,10 @@
 export interface VMixOptions {
 	host: string
 	port: number
+	/**
+	 * How often, in milliseconds, to try re-sending certain failed commands. Defaults to 10 seconds. Set to 0 to disable. As of June 9th, 2023, this only works for media loading commands.
+	 */
+	retryInterval?: number
 }
 
 export interface MappingVmixProgram {

--- a/packages/timeline-state-resolver-types/src/generated/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vmix.ts
@@ -32,7 +32,7 @@ export interface MappingVmixPreview {
 
 export interface MappingVmixInput {
 	/**
-	 * Input number or name
+	 * Input number or name. Omit if you plan to use the `filePath` property in `TimelineContentVMixInput`.
 	 */
 	index?: string
 	mappingType: MappingVmixType.Input

--- a/packages/timeline-state-resolver-types/src/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/vmix.ts
@@ -152,7 +152,7 @@ export interface TimelineContentVMixInput extends TimelineContentVMixBase {
 	/** Media file path */
 	filePath?: number | string
 
-	/** Set only when dealing with media */
+	/** Set only when dealing with media. If provided, TSR will attempt to automatically create **and potentially remove** the input. */
 	inputType?: VMixInputType
 
 	/** If media should be playing */

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -99,6 +99,7 @@
 		"eventemitter3": "^4.0.7",
 		"got": "^11.8.6",
 		"hyperdeck-connection": "^0.5.0",
+		"klona": "^2.0.6",
 		"obs-websocket-js": "^4.0.3",
 		"osc": "^2.4.4",
 		"p-all": "^3.0.0",

--- a/packages/timeline-state-resolver/src/integrations/vmix/$schemas/mappings.json
+++ b/packages/timeline-state-resolver/src/integrations/vmix/$schemas/mappings.json
@@ -36,9 +36,9 @@
 				"index": {
 					"type": "string",
 					"ui:title": "Index",
-					"ui:description": "Input number or name",
+					"ui:description": "Input number or name. Omit if you plan to use the `filePath` property in `TimelineContentVMixInput`.",
 					"ui:summaryTitle": "Index",
-					"description": "Input number or name",
+					"description": "Input number or name. Omit if you plan to use the `filePath` property in `TimelineContentVMixInput`.",
 					"TODO": "string | number. this could be done with 'anyOf' or something, but adds complexity for little benefit"
 				}
 			},

--- a/packages/timeline-state-resolver/src/integrations/vmix/$schemas/options.json
+++ b/packages/timeline-state-resolver/src/integrations/vmix/$schemas/options.json
@@ -10,6 +10,11 @@
 		"port": {
 			"type": "integer",
 			"ui:title": "Port"
+		},
+		"retryInterval": {
+			"type": "number",
+			"ui:title": "Retry Interval",
+			"description": "How often, in milliseconds, to try re-sending certain failed commands. Defaults to 10 seconds. Set to 0 to disable. As of June 9th, 2023, this only works for media loading commands."
 		}
 	},
 	"required": ["host", "port"],

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
@@ -24,7 +24,7 @@ import {
 	MappingVmixProgram,
 } from 'timeline-state-resolver-types'
 import { ThreadedClass } from 'threadedclass'
-import { VMixDevice } from '..'
+import { VMixDevice, CommandContext } from '..'
 import { MockTime } from '../../../__tests__/mockTime'
 import '../../../__tests__/lib'
 
@@ -153,7 +153,7 @@ describe('vMix', () => {
 					value: 'Video|C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -166,7 +166,7 @@ describe('vMix', () => {
 					value: 'C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -199,7 +199,7 @@ describe('vMix', () => {
 					input: 'C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -221,7 +221,7 @@ describe('vMix', () => {
 					input: 'C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -333,7 +333,7 @@ describe('vMix', () => {
 					value: 'Video|C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -346,7 +346,7 @@ describe('vMix', () => {
 					value: 'C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -380,7 +380,7 @@ describe('vMix', () => {
 					value: 10000,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -392,7 +392,7 @@ describe('vMix', () => {
 					input: 'C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -405,7 +405,7 @@ describe('vMix', () => {
 					value: 0.5,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -418,7 +418,7 @@ describe('vMix', () => {
 					value: 123,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -431,7 +431,7 @@ describe('vMix', () => {
 					value: 0.3,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -444,7 +444,7 @@ describe('vMix', () => {
 					value: 1.2,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -458,7 +458,7 @@ describe('vMix', () => {
 					value: 'G:/videos/My Other Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -472,7 +472,7 @@ describe('vMix', () => {
 					value: 5,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -484,7 +484,7 @@ describe('vMix', () => {
 					input: 'C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -623,7 +623,7 @@ describe('vMix', () => {
 					input: '2',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -635,7 +635,7 @@ describe('vMix', () => {
 					input: '2',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -649,7 +649,7 @@ describe('vMix', () => {
 					value: 'G:/videos/My Other Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -663,7 +663,7 @@ describe('vMix', () => {
 					value: 5,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -675,7 +675,7 @@ describe('vMix', () => {
 					input: '2',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -704,7 +704,7 @@ describe('vMix', () => {
 					input: '2',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -716,7 +716,7 @@ describe('vMix', () => {
 					input: '2',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -730,7 +730,7 @@ describe('vMix', () => {
 					value: '',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -744,7 +744,7 @@ describe('vMix', () => {
 					value: '',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -903,7 +903,7 @@ describe('vMix', () => {
 					value: 'Video|C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -916,7 +916,7 @@ describe('vMix', () => {
 					value: 'C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -952,7 +952,7 @@ describe('vMix', () => {
 					mix: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -966,7 +966,7 @@ describe('vMix', () => {
 					fade: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -999,7 +999,7 @@ describe('vMix', () => {
 					value: 'Video|G:/videos/My Other Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1012,7 +1012,7 @@ describe('vMix', () => {
 					value: 'G:/videos/My Other Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1027,7 +1027,7 @@ describe('vMix', () => {
 					mix: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1041,7 +1041,7 @@ describe('vMix', () => {
 					fade: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1053,7 +1053,7 @@ describe('vMix', () => {
 					input: 'C:/videos/My Clip.mp4',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -1178,7 +1178,7 @@ describe('vMix', () => {
 					fade: 1337,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1191,7 +1191,7 @@ describe('vMix', () => {
 					value: 0.12,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1203,7 +1203,7 @@ describe('vMix', () => {
 					input: '2',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1216,7 +1216,7 @@ describe('vMix', () => {
 					value: 'A',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1229,7 +1229,7 @@ describe('vMix', () => {
 					value: 'C',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1242,7 +1242,7 @@ describe('vMix', () => {
 					value: 'F',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1255,7 +1255,7 @@ describe('vMix', () => {
 					value: 'M',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1267,7 +1267,7 @@ describe('vMix', () => {
 					input: '2',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -1297,7 +1297,7 @@ describe('vMix', () => {
 					input: '2',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1311,7 +1311,7 @@ describe('vMix', () => {
 					fade: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1324,7 +1324,7 @@ describe('vMix', () => {
 					value: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1336,7 +1336,7 @@ describe('vMix', () => {
 					input: '2',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1349,7 +1349,7 @@ describe('vMix', () => {
 					value: 'M',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1362,7 +1362,7 @@ describe('vMix', () => {
 					value: 'A',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1375,7 +1375,7 @@ describe('vMix', () => {
 					value: 'C',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1388,7 +1388,7 @@ describe('vMix', () => {
 					value: 'F',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -1598,7 +1598,7 @@ describe('vMix', () => {
 					mix: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1613,7 +1613,7 @@ describe('vMix', () => {
 					mix: 1,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1626,7 +1626,7 @@ describe('vMix', () => {
 					mix: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -1639,7 +1639,7 @@ describe('vMix', () => {
 					mix: 1,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -1752,7 +1752,7 @@ describe('vMix', () => {
 					value: 2,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -1775,7 +1775,7 @@ describe('vMix', () => {
 					value: 2,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -1878,7 +1878,7 @@ describe('vMix', () => {
 					command: VMixCommand.START_RECORDING,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -1900,7 +1900,7 @@ describe('vMix', () => {
 					command: VMixCommand.STOP_RECORDING,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2003,7 +2003,7 @@ describe('vMix', () => {
 					command: VMixCommand.START_EXTERNAL,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2025,7 +2025,7 @@ describe('vMix', () => {
 					command: VMixCommand.STOP_EXTERNAL,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2128,7 +2128,7 @@ describe('vMix', () => {
 					command: VMixCommand.START_STREAMING,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2150,7 +2150,7 @@ describe('vMix', () => {
 					command: VMixCommand.STOP_STREAMING,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2256,7 +2256,7 @@ describe('vMix', () => {
 					value: 'Preview',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2280,7 +2280,7 @@ describe('vMix', () => {
 					value: 'Output',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2388,7 +2388,7 @@ describe('vMix', () => {
 					input: 2,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2412,7 +2412,7 @@ describe('vMix', () => {
 					value: 'Output',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2515,7 +2515,7 @@ describe('vMix', () => {
 					command: VMixCommand.FADE_TO_BLACK,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2537,7 +2537,7 @@ describe('vMix', () => {
 					command: VMixCommand.FADE_TO_BLACK,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2641,7 +2641,7 @@ describe('vMix', () => {
 					value: 126,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2664,7 +2664,7 @@ describe('vMix', () => {
 					value: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2768,7 +2768,7 @@ describe('vMix', () => {
 					value: 'myscript',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2872,7 +2872,7 @@ describe('vMix', () => {
 					value: 'myscript',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -2892,7 +2892,7 @@ describe('vMix', () => {
 					value: 'myscript',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -3275,7 +3275,7 @@ describe('vMix', () => {
 					input: '1',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -3287,7 +3287,7 @@ describe('vMix', () => {
 					input: '1',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -3394,7 +3394,7 @@ describe('vMix', () => {
 					value: 'C:\\foo.mov',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 
@@ -3562,7 +3562,7 @@ describe('vMix', () => {
 					mix: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -3576,7 +3576,7 @@ describe('vMix', () => {
 					index: 1,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -3591,7 +3591,7 @@ describe('vMix', () => {
 					mix: 0,
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -3603,7 +3603,7 @@ describe('vMix', () => {
 					input: '1',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
@@ -3615,7 +3615,7 @@ describe('vMix', () => {
 					input: '1',
 				},
 			}),
-			null,
+			CommandContext.None,
 			expect.any(String)
 		)
 

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -52,7 +52,7 @@ export type CommandReceiver = (
 	timelineObjId: string
 	layer: string
 }*/
-enum CommandContext {
+export enum CommandContext {
 	None = 'none',
 	Retry = 'retry',
 }

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -1307,15 +1307,13 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 		const confirmedState = cloneDeep(currentExpectedState.state)
 
 		for (const [inputName, input] of Object.entries<VMixInput>(currentExpectedState.state.reportedState.inputs)) {
-			if (input.filePath) {
-				// Currently disabled because, as far as we can tell, input.filePath
-				// doesn't actually currently do anything in TSR...
-				// if (input.filePath === fileNotFoundMatch.groups.fileName) {
-				// 	if (inputName in confirmedState.reportedState.inputs) {
-				// 		// This will cause the diff to generate a new command to load the file.
-				// 		delete confirmedState.reportedState.inputs[inputName].filePath
-				// 	}
-				// }
+			if (input.filePath || (input.type && input.type !== VMixInputType.List)) {
+				if (input.filePath === fileNotFoundMatch.groups.fileName || input.name === fileNotFoundMatch.groups.fileName) {
+					if (inputName in confirmedState.reportedState.inputs) {
+						// This will cause the diff to generate a new command to create the input.
+						delete confirmedState.reportedState.inputs[inputName]
+					}
+				}
 			} else if (input.listFilePaths) {
 				if (input.listFilePaths.includes(fileNotFoundMatch.groups.fileName)) {
 					if (inputName in confirmedState.reportedState.inputs) {

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -4,7 +4,7 @@ import * as deepMerge from 'deepmerge'
 import { DeviceWithState, CommandWithContext, DeviceStatus, StatusCode } from './../../devices/device'
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
 
-import { VMix, VMixStateCommand } from './connection'
+import { VMix, VMixStateCommand, Response as VMixResponse } from './connection'
 import {
 	DeviceType,
 	DeviceOptionsVMix,
@@ -28,7 +28,13 @@ import {
 	SavePresetPayload,
 	VmixActions,
 } from 'timeline-state-resolver-types'
-import { t } from '../../lib'
+import { cloneDeep, t } from '../../lib'
+
+/**
+ * Default time, in milliseconds, for when we should retry loading media files.
+ */
+const DEFAULT_MEDIA_RETRY_INTERVAL = 10 * 1000
+const FILE_NOT_FOUND_REGEX = /File Not Found: (?<fileName>.+)/i
 
 export interface DeviceOptionsVMixInternal extends DeviceOptionsVMix {
 	commandReceiver?: CommandReceiver
@@ -46,7 +52,10 @@ export type CommandReceiver = (
 	timelineObjId: string
 	layer: string
 }*/
-type CommandContext = any
+enum CommandContext {
+	None = 'none',
+	Retry = 'retry',
+}
 export interface VMixStateCommandWithContext {
 	command: VMixStateCommand
 	context: CommandContext
@@ -78,6 +87,20 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 	private _vmix: VMix
 	private _connected = false
 	private _initialized = false
+	private _retryTimeout: NodeJS.Timeout
+	private _retryTime: number | null = null
+	/**
+	 * Our best guess as to what the real state of vMix is at this moment.
+	 * This is *not* the same thing as `this._vmix.state.reportedState`,
+	 * even though they seem and sound very similar. The difference is that
+	 * this reacts to incoming command error messages (specifically for media loading)
+	 * and updates itself based on those. From there, it is used to generate diffs that
+	 * are used to re-send failed commands (again, specifically for media loading).
+	 *
+	 * In short: this uses a heuristic to guess the real state of vMix,
+	 * spefically its media statuses.
+	 */
+	private _bestGuessActualState: VMixStateExtended | null = null
 
 	constructor(deviceId: string, deviceOptions: DeviceOptionsVMixInternal, getCurrentTime: () => Promise<number>) {
 		super(deviceId, deviceOptions, getCurrentTime)
@@ -124,11 +147,18 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 					this.emit('connectionChanged', this.getStatus())
 					this.emit('resetResolver')
 				}
+			} else if (d.response === 'ER' && FILE_NOT_FOUND_REGEX.test(d.message)) {
+				this._changeTrackedStateFromIncomingData(d)
 			}
 		})
 		// this._vmix.on('debug', (...args) => this.emitDebug(...args))
 
 		this._vmix.connect()
+
+		if (typeof options.retryInterval !== 'number' || options.retryInterval > 0) {
+			this._retryTime = options.retryInterval ?? DEFAULT_MEDIA_RETRY_INTERVAL
+			this._retryTimeout = setTimeout(() => this._assertIntendedState(), this._retryTime)
+		}
 
 		return true
 	}
@@ -267,6 +297,8 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 
 		this._vmix.removeAllListeners()
 		this._vmix.disconnect()
+
+		clearTimeout(this._retryTimeout)
 
 		return Promise.resolve(true)
 	}
@@ -599,7 +631,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							duration: changeOnLayer ? 0 : newMixState.transition.duration,
 							mix: i,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				}
@@ -616,7 +648,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						input: newMixState.preview,
 						mix: i,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -629,7 +661,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.FADER,
 						value: newVMixState.reportedState.faderPosition || 0,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 				// newVMixState.reportedState.program = undefined
@@ -643,7 +675,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 				command: {
 					command: VMixCommand.FADE_TO_BLACK,
 				},
-				context: null,
+				context: CommandContext.None,
 				timelineId: '',
 			})
 		}
@@ -670,7 +702,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.ADD_INPUT,
 						value: `${input.type}|${input.name}`,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 				addCommands.push({
@@ -679,7 +711,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						input: this.getFilename(input.name),
 						value: input.name,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 				this._addToQueue(addCommands, this.getCurrentTime())
@@ -716,7 +748,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							command: VMixCommand.PAUSE_INPUT,
 							input: input.name,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				}
@@ -725,7 +757,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.LIST_REMOVE_ALL,
 						input: input.name,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 				if (Array.isArray(input.listFilePaths)) {
@@ -736,7 +768,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 								input: input.name,
 								value: filePath,
 							},
-							context: null,
+							context: CommandContext.None,
 							timelineId: '',
 						})
 					}
@@ -748,7 +780,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.PAUSE_INPUT,
 						input: input.name,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -759,7 +791,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						input: key,
 						value: input.position ? input.position : 0,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -769,7 +801,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.RESTART_INPUT,
 						input: key,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -780,7 +812,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							command: VMixCommand.LOOP_ON,
 							input: input.name,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				} else {
@@ -789,7 +821,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							command: VMixCommand.LOOP_OFF,
 							input: input.name,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				}
@@ -800,7 +832,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.AUDIO_OFF,
 						input: key,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -812,7 +844,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						value: input.volume,
 						fade: input.fade,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -823,7 +855,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						input: key,
 						value: input.balance,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -834,7 +866,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							command: VMixCommand.AUDIO_AUTO_OFF,
 							input: key,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				} else {
@@ -843,7 +875,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							command: VMixCommand.AUDIO_AUTO_ON,
 							input: key,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				}
@@ -858,7 +890,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							input: key,
 							value: bus,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				})
@@ -869,7 +901,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							input: key,
 							value: bus,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				})
@@ -880,7 +912,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.AUDIO_ON,
 						input: key,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -892,7 +924,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							input: key,
 							value: input.transform.zoom,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				}
@@ -903,7 +935,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							input: key,
 							value: input.transform.alpha,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				}
@@ -914,7 +946,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							input: key,
 							value: input.transform.panX,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				}
@@ -925,7 +957,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							input: key,
 							value: input.transform.panY,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				}
@@ -940,7 +972,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 								value: input.overlays![Number(index)],
 								index: Number(index),
 							},
-							context: null,
+							context: CommandContext.None,
 							timelineId: '',
 						})
 					}
@@ -954,7 +986,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 								value: '',
 								index: Number(index),
 							},
-							context: null,
+							context: CommandContext.None,
 							timelineId: '',
 						})
 					}
@@ -966,7 +998,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.PLAY_INPUT,
 						input: input.name,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -990,7 +1022,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.REMOVE_INPUT,
 						input: oldVMixState.reportedState.inputs[input].name || input,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -1012,7 +1044,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							command: VMixCommand.OVERLAY_INPUT_OUT,
 							value: overlay.number,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				} else {
@@ -1022,7 +1054,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 							input: overlay.input,
 							value: overlay.number,
 						},
-						context: null,
+						context: CommandContext.None,
 						timelineId: '',
 					})
 				}
@@ -1042,7 +1074,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 					command: {
 						command: VMixCommand.START_RECORDING,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			} else {
@@ -1050,7 +1082,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 					command: {
 						command: VMixCommand.STOP_RECORDING,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -1069,7 +1101,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 					command: {
 						command: VMixCommand.START_STREAMING,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			} else {
@@ -1077,7 +1109,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 					command: {
 						command: VMixCommand.STOP_STREAMING,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -1096,7 +1128,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 					command: {
 						command: VMixCommand.START_EXTERNAL,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			} else {
@@ -1104,7 +1136,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 					command: {
 						command: VMixCommand.STOP_EXTERNAL,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -1129,7 +1161,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						input: output.input,
 						name,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -1150,7 +1182,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.SCRIPT_START,
 						value: name,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -1163,7 +1195,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 						command: VMixCommand.SCRIPT_STOP,
 						value: name,
 					},
-					context: null,
+					context: CommandContext.None,
 					timelineId: '',
 				})
 			}
@@ -1198,6 +1230,12 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 		context: CommandContext,
 		timelineObjId: string
 	): Promise<any> {
+		// do not retry while we are sending commands, instead always retry closely after:
+		if (context !== CommandContext.Retry) {
+			clearTimeout(this._retryTimeout)
+			if (this._retryTime) this._retryTimeout = setTimeout(() => this._assertIntendedState(), this._retryTime)
+		}
+
 		const cwc: CommandWithContext = {
 			context: context,
 			command: cmd,
@@ -1254,6 +1292,82 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 
 		return false
 	}
+
+	/**
+	 * Receives incoming data (i.e. command responses, though it may be subscription data too)
+	 * from vMix and changes our tracked state based on the contents of that data.
+	 */
+	private _changeTrackedStateFromIncomingData(data: VMixResponse): void {
+		const currentExpectedState = this.getState(this.getCurrentTime())
+		if (!currentExpectedState) return
+
+		const fileNotFoundMatch = data.message.match(FILE_NOT_FOUND_REGEX)
+		if (!fileNotFoundMatch?.groups) return // We only handle "file not found" responses, so ignore everything else.
+
+		const confirmedState = cloneDeep(currentExpectedState.state)
+
+		for (const [inputName, input] of Object.entries<VMixInput>(currentExpectedState.state.reportedState.inputs)) {
+			if (input.filePath) {
+				// Currently disabled because, as far as we can tell, input.filePath
+				// doesn't actually currently do anything in TSR...
+				// if (input.filePath === fileNotFoundMatch.groups.fileName) {
+				// 	if (inputName in confirmedState.reportedState.inputs) {
+				// 		// This will cause the diff to generate a new command to load the file.
+				// 		delete confirmedState.reportedState.inputs[inputName].filePath
+				// 	}
+				// }
+			} else if (input.listFilePaths) {
+				if (input.listFilePaths.includes(fileNotFoundMatch.groups.fileName)) {
+					if (inputName in confirmedState.reportedState.inputs) {
+						// This will cause the diff to generate a new command to load the file.
+						confirmedState.reportedState.inputs[inputName].listFilePaths = input.listFilePaths.filter(
+							(fp) => fp !== fileNotFoundMatch.groups!.fileName
+						)
+					}
+				}
+			}
+		}
+
+		this._bestGuessActualState = confirmedState
+	}
+
+	/**
+	 * Takes the current timeline-state and diffs it with the known
+	 * vMix state. If any media has failed to load, it will create a diff with
+	 * the intended (timeline) state and that command will be executed.
+	 */
+	private _assertIntendedState() {
+		if (this._retryTime) {
+			this._retryTimeout = setTimeout(() => this._assertIntendedState(), this._retryTime)
+		}
+
+		if (!this._bestGuessActualState) return
+
+		const tlState = this.getState(this.getCurrentTime())
+
+		if (!tlState) return // no state implies any state is correct
+
+		const vmixState = tlState.state
+
+		const diff = this._diffStates(this._bestGuessActualState, vmixState)
+
+		const cmds: Array<VMixStateCommandWithContext> = []
+		for (const cmd of diff) {
+			// This system currently only handles media loading commands. Others could be added in the future.
+			if (cmd.command.command === VMixCommand.ADD_INPUT || cmd.command.command === VMixCommand.LIST_ADD) {
+				cmd.context = CommandContext.Retry
+				cmds.push(cmd)
+			}
+		}
+
+		if (cmds.length > 0) {
+			this._addToQueue(cmds, this.getCurrentTime())
+		}
+
+		// We have to now blindly hope that our sent commands will work.
+		// If not, that's okay, because we'll get new errors for them and the cycle will begin anew.
+		this._bestGuessActualState = vmixState
+	}
 }
 
 interface VMixOutput {
@@ -1262,6 +1376,12 @@ interface VMixOutput {
 }
 
 export interface VMixStateExtended {
+	/**
+	 * The state of vMix (as far as we know) as reported by vMix **+
+	 * our expectations based on the commands we've set**.
+	 * This might not align with reality, or it may lag behind reality, partially
+	 * because there's no good way to subscribe to vMix's state via its API.
+	 */
 	reportedState: VMixState
 	outputs: {
 		External2: VMixOutput

--- a/packages/timeline-state-resolver/src/lib.ts
+++ b/packages/timeline-state-resolver/src/lib.ts
@@ -1,3 +1,4 @@
+import { klona } from 'klona'
 import {
 	Datastore,
 	Timeline,
@@ -287,4 +288,8 @@ export function actionNotFoundMessage(id: string) {
 		result: ActionExecutionResultCode.Error,
 		response: t('Action "{{id}}" not found', { id }),
 	}
+}
+
+export function cloneDeep<T>(input: T): T {
+	return klona(input)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7324,6 +7324,13 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
+"klona@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "klona@npm:2.0.6"
+  checksum: ac9ee3732e42b96feb67faae4d27cf49494e8a3bf3fa7115ce242fe04786788e0aff4741a07a45a2462e2079aa983d73d38519c85d65b70ef11447bbc3c58ce7
+  languageName: node
+  linkType: hard
+
 "lazystream@npm:^1.0.0":
   version: 1.0.1
   resolution: "lazystream@npm:1.0.1"
@@ -11370,6 +11377,7 @@ asn1@evs-broadcast/node-asn1:
     i18next-conv: ^13.1.1
     i18next-parser: ^6.6.0
     json-schema-to-typescript: ^10.1.5
+    klona: ^2.0.6
     obs-websocket-js: ^4.0.3
     osc: ^2.4.4
     p-all: ^3.0.0


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

If TSR sends a media load command which fails due the file not being found, TSR will not retry loading that file.

* **What is the new behavior (if this is a feature change)?**

TSR will retry loading media files that are not found until it succeeds.

* **Other information**:

I added some additional comments to the code to clarify things which confused me. I also tested everything via quickTSR.