### PR TITLE
fix: vmix: don't join response packets together with an extraneous newline

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -133,7 +133,7 @@ export class BaseConnection extends EventEmitter<ConnectionEvents> {
 						len -= l.length + 2
 						lines.push(l)
 					}
-					response.body = lines.join('\r\n')
+					response.body = lines.join('')
 					processedLines += lines.length
 				}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Under certain conditions, such as when running in Docker, TSR can fail to stitch together multi-packet responses from vMix (such as the `XML` response), leading to the device never initializing and therefore not working.

* **What is the new behavior (if this is a feature change)?**

Multi-packet responses are no longer joined together with an extra newline. I'm reasonably confident that we never want this newline, but perhaps I'm not seeing some scenario where the addition of a newline needs to be conditional.

* **Other information**:

I have no idea how this bug is different from #249, but it is. I don't know why that other PR fixed the bug at the time.