### PR TITLE
chore(vmix): add state debugging

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -285,6 +285,8 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 
 		// store the new state, for later use:
 		this.setState(newVMixState, newState.time)
+
+		this.emitDebugState(newVMixState)
 	}
 
 	clearFuture(clearAfterTime: number) {


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore or mild feature.

* **What is the current behavior?** (You can also link to an open issue here)

The vMix device does not offer state debugging.

* **What is the new behavior (if this is a feature change)?**

This vMix device will now emit a new debug state on every timeline received.

* **Other information**:

None.