### PR TITLE
fix(httpSend): Use the same types for the sendCommand action as a timeline object

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/generated/httpSend.ts
@@ -46,16 +46,7 @@ export enum TimelineContentTypeHTTPParamType {
 
 export type SomeMappingHttpSend = Record<string, never>
 
-export interface SendCommandPayload {
-	type: string
-	url: string
-	params: {
-		[k: string]: unknown
-	}
-	paramsType?: string
-	temporalPriority?: number
-	queueId?: string
-}
+export type SendCommandPayload = HTTPSendCommandContent
 
 export enum HttpSendActions {
 	Resync = 'resync',

--- a/packages/timeline-state-resolver/src/integrations/httpSend/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/$schemas/actions.json
@@ -12,18 +12,9 @@
 			"destructive": false,
 			"payload": {
 				"type": "object",
-				"properties": {
-					"type": {
-						"type": "string"
-					},
-					"url": { "type": "string" },
-					"params": { "type": "object" },
-					"paramsType": { "type": "string" },
-					"temporalPriority": { "type": "number" },
-					"queueId": { "type": "string" }
-				},
-				"additionalProperties": false,
-				"required": ["type", "url", "params"]
+				"properties": {},
+				"tsType": "HTTPSendCommandContent",
+				"additionalProperties": false
 			}
 		}
 	]

--- a/packages/timeline-state-resolver/src/integrations/httpSend/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/$schemas/actions.json
@@ -12,8 +12,53 @@
 			"destructive": false,
 			"payload": {
 				"type": "object",
-				"properties": {},
 				"tsType": "HTTPSendCommandContent",
+				"properties": {
+					"type": {
+						"type": "string",
+						"title": "TimelineContentTypeHTTP",
+						"ui:title": "Type",
+						"ui:summaryTitle": "Type",
+						"default": "",
+						"enum": ["get", "post", "put", "delete"],
+						"tsEnumNames": ["GET", "POST", "PUT", "DELETE"]
+					},
+					"url": {
+						"type": "string",
+						"ui:title": "Url",
+						"ui:summaryTitle": "URL",
+						"default": ""
+					},
+					"params": {
+						"type": "object",
+						"ui:title": "Params",
+						"ui:displayType": "json",
+						"additionalProperties": true
+					},
+					"paramsType": {
+						"type": "string",
+						"title": "TimelineContentTypeHTTPParamType",
+						"ui:title": "Params type",
+						"default": "json",
+						"enum": ["json", "form"],
+						"tsEnumNames": ["JSON", "FORM"]
+					},
+					"headers": {
+						"type": "object",
+						"additionalProperties": { "type": "string" }
+					},
+					"temporalPriority": {
+						"type": "integer",
+						"ui:title": "Temporal Priority",
+						"default": 0
+					},
+					"queueId": {
+						"type": "string",
+						"description": "Commands in the same queue will be sent in order (will wait for the previous to finish before sending next",
+						"ui:title": "Send Queue Id"
+					}
+				},
+				"required": ["type", "url", "params"],
 				"additionalProperties": false
 			}
 		}

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -155,7 +155,7 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 				response: t('Failed to send command: Missing url'),
 			}
 		}
-		if (Object.values<TimelineContentTypeHTTP>(TimelineContentTypeHTTP).includes(cmd.type as TimelineContentTypeHTTP)) {
+		if (Object.values<TimelineContentTypeHTTP>(TimelineContentTypeHTTP).includes(cmd.type)) {
 			return {
 				result: ActionExecutionResultCode.Error,
 				response: t('Failed to send command: type is invalid'),
@@ -174,7 +174,7 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 			}
 		}
 
-		await this._commandReceiver(time, cmd as HTTPSendCommandContent, 'makeReady', '')
+		await this._commandReceiver(time, cmd, 'makeReady', '')
 
 		return {
 			result: ActionExecutionResultCode.Ok,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
httpSend SendCommand TSR action has a separate less well typed payload (and is missing the headers property)


* **What is the new behavior (if this is a feature change)?**
SendCommand payload now inherits from the normal httpSend TSR type