### PR TITLE
chore: convert http device & cache dns reqs

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/generated/httpSend.ts
@@ -7,41 +7,9 @@
 
 export interface HTTPSendOptions {
 	/**
-	 * Whether a makeReady should be treated as a reset of the device. It should be assumed clean, with the queue discarded, and state reapplied from empty
-	 */
-	makeReadyDoesReset?: boolean
-	/**
 	 * Minimum time in ms before a command is resent, set to <= 0 or undefined to disable
 	 */
 	resendTime?: number
-	makeReadyCommands?: HTTPSendCommandContent[]
-}
-export interface HTTPSendCommandContent {
-	type: TimelineContentTypeHTTP
-	url: string
-	params: {
-		[k: string]: unknown
-	}
-	paramsType?: TimelineContentTypeHTTPParamType
-	headers?: {
-		[k: string]: string
-	}
-	temporalPriority?: number
-	/**
-	 * Commands in the same queue will be sent in order (will wait for the previous to finish before sending next
-	 */
-	queueId?: string
-}
-
-export enum TimelineContentTypeHTTP {
-	GET = 'get',
-	POST = 'post',
-	PUT = 'put',
-	DELETE = 'delete'
-}
-export enum TimelineContentTypeHTTPParamType {
-	JSON = 'json',
-	FORM = 'form'
 }
 
 export type SomeMappingHttpSend = Record<string, never>

--- a/packages/timeline-state-resolver-types/src/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/httpSend.ts
@@ -1,4 +1,4 @@
-import { DeviceType, HTTPSendCommandContent } from '.'
+import { DeviceType } from '.'
 
 export type TimelineContentHTTPSendAny = TimelineContentHTTPRequest
 export interface TimelineContentHTTPSendBase {
@@ -6,3 +6,31 @@ export interface TimelineContentHTTPSendBase {
 }
 
 export type TimelineContentHTTPRequest = TimelineContentHTTPSendBase & HTTPSendCommandContent
+
+export interface HTTPSendCommandContent {
+	type: TimelineContentTypeHTTP
+	url: string
+	params: {
+		[k: string]: unknown
+	}
+	paramsType?: TimelineContentTypeHTTPParamType
+	headers?: {
+		[k: string]: string
+	}
+	temporalPriority?: number
+	/**
+	 * Commands in the same queue will be sent in order (will wait for the previous to finish before sending next
+	 */
+	queueId?: string
+}
+
+export enum TimelineContentTypeHTTP {
+	GET = 'get',
+	POST = 'post',
+	PUT = 'put',
+	DELETE = 'delete',
+}
+export enum TimelineContentTypeHTTPParamType {
+	JSON = 'json',
+	FORM = 'form',
+}

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -91,6 +91,7 @@
 		"@tv2media/v-connection": "^7.3.0",
 		"atem-connection": "2.4.0",
 		"atem-state": "^0.12.2",
+		"cacheable-lookup": "^5.0.3",
 		"casparcg-connection": "^6.0.3",
 		"casparcg-state": "^3.0.2",
 		"debug": "^4.3.4",

--- a/packages/timeline-state-resolver/src/__tests__/conductor.spec.ts
+++ b/packages/timeline-state-resolver/src/__tests__/conductor.spec.ts
@@ -329,9 +329,6 @@ describe('Conductor', () => {
 		const commandReceiver2 = jest.fn(async () => {
 			return Promise.resolve()
 		})
-		const commandReceiver3 = jest.fn(async () => {
-			return Promise.resolve()
-		})
 		const commandReceiver4 = jest.fn(async () => {
 			return Promise.resolve()
 		})
@@ -363,7 +360,6 @@ describe('Conductor', () => {
 		await conductor.addDevice('device3', {
 			type: DeviceType.HTTPSEND,
 			options: {},
-			commandReceiver: commandReceiver3,
 		})
 		await conductor.addDevice('device4', {
 			type: DeviceType.LAWO,

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -32,7 +32,7 @@ import { DeviceContainer } from './devices/deviceContainer'
 
 import { CasparCGDevice, DeviceOptionsCasparCGInternal } from './integrations/casparCG'
 import { AbstractDevice, DeviceOptionsAbstractInternal } from './integrations/abstract'
-import { HTTPSendDevice, DeviceOptionsHTTPSendInternal } from './integrations/httpSend'
+import { DeviceOptionsHTTPSendInternal } from './integrations/httpSend'
 import { AtemDevice, DeviceOptionsAtemInternal } from './integrations/atem'
 import { LawoDevice, DeviceOptionsLawoInternal } from './integrations/lawo'
 import { PanasonicPtzDevice, DeviceOptionsPanasonicPTZInternal } from './integrations/panasonicPTZ'
@@ -524,15 +524,6 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 					getCurrentTime,
 					threadedClassOptions
 				)
-			case DeviceType.HTTPSEND:
-				return DeviceContainer.create<DeviceOptionsHTTPSendInternal, typeof HTTPSendDevice>(
-					'../../dist/integrations/httpSend/index.js',
-					'HTTPSendDevice',
-					deviceId,
-					deviceOptions,
-					getCurrentTime,
-					threadedClassOptions
-				)
 			case DeviceType.HTTPWATCHER:
 				return DeviceContainer.create<DeviceOptionsHTTPWatcherInternal, typeof HTTPWatcherDevice>(
 					'../../dist/integrations/httpWatcher/index.js',
@@ -686,6 +677,7 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 					getCurrentTime,
 					threadedClassOptions
 				)
+			case DeviceType.HTTPSEND:
 			case DeviceType.OSC:
 				// presumably this device is implemented in the new service handler
 				return RemoteDeviceInstance.create(

--- a/packages/timeline-state-resolver/src/integrations/httpSend/$schemas/options.json
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/$schemas/options.json
@@ -3,76 +3,14 @@
 	"title": "HTTP Send Options",
 	"type": "object",
 	"properties": {
-		"makeReadyDoesReset": {
-			"type": "boolean",
-			"ui:title": "Whether Make Ready triggers a state reset",
-			"description": "Whether a makeReady should be treated as a reset of the device. It should be assumed clean, with the queue discarded, and state reapplied from empty",
-			"default": false
-		},
 		"resendTime": {
 			"type": "integer",
 			"description": "Minimum time in ms before a command is resent, set to <= 0 or undefined to disable",
 			"ui:description": "Minimum time in ms before a command is resent, set to a number > 0 to enable",
 			"ui:title": "Resend time in ms",
 			"default": 0
-		},
-		"makeReadyCommands": {
-			"type": "array",
-			"ui:title": "Make Ready Commands",
-			"items": {
-				"type": "object",
-				"title": "HTTPSendCommandContent",
-				"todo": "should this be pulled in from elsewhere? its a timeline object type too",
-				"properties": {
-					"type": {
-						"type": "string",
-						"title": "TimelineContentTypeHTTP",
-						"ui:title": "Type",
-						"ui:summaryTitle": "Type",
-						"default": "",
-						"enum": ["get", "post", "put", "delete"],
-						"tsEnumNames": ["GET", "POST", "PUT", "DELETE"]
-					},
-					"url": {
-						"type": "string",
-						"ui:title": "Url",
-						"ui:summaryTitle": "URL",
-						"default": ""
-					},
-					"params": {
-						"type": "object",
-						"ui:title": "Params",
-						"ui:displayType": "json",
-						"additionalProperties": true
-					},
-					"paramsType": {
-						"type": "string",
-						"title": "TimelineContentTypeHTTPParamType",
-						"ui:title": "Params type",
-						"default": "json",
-						"enum": ["json", "form"],
-						"tsEnumNames": ["JSON", "FORM"]
-					},
-					"headers": {
-						"type": "object",
-						"additionalProperties": { "type": "string" }
-					},
-					"temporalPriority": {
-						"type": "integer",
-						"ui:title": "Temporal Priority",
-						"default": 0
-					},
-					"queueId": {
-						"type": "string",
-						"description": "Commands in the same queue will be sent in order (will wait for the previous to finish before sending next",
-						"ui:title": "Send Queue Id"
-					}
-				},
-				"required": ["type", "url", "params"],
-				"additionalProperties": false
-			}
 		}
 	},
-	"required": ["host"],
+	"required": [],
 	"additionalProperties": false
 }

--- a/packages/timeline-state-resolver/src/integrations/httpSend/__tests__/httpsend.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/__tests__/httpsend.spec.ts
@@ -1,4 +1,9 @@
-import { DeviceType, TimelineContentTypeHTTP } from 'timeline-state-resolver-types'
+import {
+	ActionExecutionResultCode,
+	DeviceType,
+	HttpSendActions,
+	TimelineContentTypeHTTP,
+} from 'timeline-state-resolver-types'
 import { TimelineContentHTTPSendAny } from 'timeline-state-resolver-types'
 import { Timeline } from 'timeline-state-resolver-types'
 import { TSRTimelineContent } from 'timeline-state-resolver-types'
@@ -283,6 +288,24 @@ describe('HTTP-Send', () => {
 			expect(MOCKED_SOCKET_GET).toHaveBeenCalledTimes(2)
 			jest.advanceTimersByTime(1000)
 			expect(MOCKED_SOCKET_GET).toHaveBeenCalledTimes(2)
+		})
+	})
+
+	describe('Send action', () => {
+		test('Send action', async () => {
+			const device = await getInitialisedHttpDevice()
+
+			const result = await device.actions[HttpSendActions.SendCommand](HttpSendActions.SendCommand, {
+				...DEFAULT_TL_CONTENT,
+				type: TimelineContentTypeHTTP.GET,
+				url: 'http://testurl',
+				params: {},
+			})
+
+			expect(MOCKED_SOCKET_GET).toHaveBeenCalledTimes(1)
+			expect(result).toMatchObject({
+				result: ActionExecutionResultCode.Ok,
+			})
 		})
 	})
 })

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -1,154 +1,76 @@
-import * as _ from 'underscore'
-import { DeviceWithState, CommandWithContext, DeviceStatus, StatusCode } from './../../devices/device'
+import { EventEmitter } from 'eventemitter3'
+import { CommandWithContext, Device, DeviceEvents } from '../../service/device'
 import {
-	DeviceType,
-	HTTPSendOptions,
-	HTTPSendCommandContent,
-	DeviceOptionsHTTPSend,
-	Mappings,
-	Timeline,
-	TSRTimelineContent,
-	TimelineContentTypeHTTP,
-	TimelineContentTypeHTTPParamType,
 	ActionExecutionResult,
 	ActionExecutionResultCode,
+	DeviceOptionsHTTPSend,
+	DeviceStatus,
+	HTTPSendCommandContent,
+	HTTPSendOptions,
 	HttpSendActions,
 	SendCommandPayload,
+	StatusCode,
+	TSRTimelineContent,
+	Timeline,
+	TimelineContentTypeHTTP,
+	TimelineContentTypeHTTPParamType,
 } from 'timeline-state-resolver-types'
-import { DoOnTime, SendMode } from '../../devices/doOnTime'
+import _ = require('underscore')
 import got, { OptionsOfTextResponseBody, RequestError } from 'got'
-import { actionNotFoundMessage, endTrace, startTrace } from '../../lib'
-
-import Debug from 'debug'
 import { t } from '../../lib'
-const debug = Debug('timeline-state-resolver:httpsend')
+import CacheableLookup from 'cacheable-lookup'
 
-export interface DeviceOptionsHTTPSendInternal extends DeviceOptionsHTTPSend {
-	commandReceiver?: CommandReceiver
+type DeviceOptions = HTTPSendOptions
+export type HttpSendDeviceState = Timeline.TimelineState<TSRTimelineContent>
+
+export interface HttpSendDeviceCommand extends CommandWithContext {
+	command: {
+		commandName: 'added' | 'changed' | 'removed' | 'retry' | 'manual'
+		content: HTTPSendCommandContent
+		layer: string
+	}
 }
-export type CommandReceiver = (
-	time: number,
-	cmd: HTTPSendCommandContent,
-	context: CommandContext,
-	timelineObjId: string,
-	layer?: string
-) => Promise<any>
-interface Command {
-	commandName: 'added' | 'changed' | 'removed'
-	content: HTTPSendCommandContent
-	context: CommandContext
-	timelineObjId: string
-	layer: string
-}
-type CommandContext = string
 
-type HTTPSendState = Timeline.TimelineState<TSRTimelineContent>
+export type DeviceOptionsHTTPSendInternal = DeviceOptionsHTTPSend
 
-/**
- * This is a HTTPSendDevice, it sends http commands when it feels like it
- */
-export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptionsHTTPSendInternal> {
-	private _makeReadyCommands: HTTPSendCommandContent[]
-	private _makeReadyDoesReset: boolean
-	private _resendTime?: number
-	private _doOnTime: DoOnTime
-
-	private _commandReceiver: CommandReceiver
+export class HTTPSendDevice
+	extends EventEmitter<DeviceEvents>
+	implements Device<DeviceOptions, HttpSendDeviceState, HttpSendDeviceCommand>
+{
+	private options: DeviceOptions
 	private activeLayers = new Map<string, string>()
+	private cacheable: CacheableLookup
 
-	constructor(deviceId: string, deviceOptions: DeviceOptionsHTTPSendInternal, getCurrentTime: () => Promise<number>) {
-		super(deviceId, deviceOptions, getCurrentTime)
-		if (deviceOptions.options) {
-			if (deviceOptions.commandReceiver) this._commandReceiver = deviceOptions.commandReceiver
-			else this._commandReceiver = this._defaultCommandReceiver.bind(this)
-		}
-		this._doOnTime = new DoOnTime(
-			() => {
-				return this.getCurrentTime()
-			},
-			SendMode.IN_ORDER,
-			this._deviceOptions
-		)
-		this.handleDoOnTime(this._doOnTime, 'HTTPSend')
+	async init(options: DeviceOptions): Promise<boolean> {
+		this.options = options
+		this.cacheable = new CacheableLookup()
+		return true
 	}
-	async init(initOptions: HTTPSendOptions): Promise<boolean> {
-		this._makeReadyCommands = initOptions.makeReadyCommands || []
-		this._makeReadyDoesReset = initOptions.makeReadyDoesReset || false
-		this._resendTime = initOptions.resendTime && initOptions.resendTime > 1 ? initOptions.resendTime : undefined
-
-		return Promise.resolve(true) // This device doesn't have any initialization procedure
+	async terminate(): Promise<boolean> {
+		return true
 	}
-	/** Called by the Conductor a bit before a .handleState is called */
-	prepareForHandleState(newStateTime: number) {
-		// clear any queued commands later than this time:
-		this._doOnTime.clearQueueNowAndAfter(newStateTime)
-		this.cleanUpStates(0, newStateTime)
+
+	get connected(): boolean {
+		return false
 	}
-	handleState(newState: Timeline.TimelineState<TSRTimelineContent>, newMappings: Mappings) {
-		super.onHandleState(newState, newMappings)
-		// Handle this new state, at the point in time specified
-
-		const previousStateTime = Math.max(this.getCurrentTime(), newState.time)
-		const oldState: Timeline.TimelineState<TSRTimelineContent> = (
-			this.getStateBefore(previousStateTime) || { state: { time: 0, layers: {}, nextEvents: [] } }
-		).state
-
-		const convertTrace = startTrace(`device:convertState`, { deviceId: this.deviceId })
-		const oldHttpSendState = oldState
-		const newHttpSendState = this.convertStateToHttpSend(newState)
-		this.emit('timeTrace', endTrace(convertTrace))
-
-		const diffTrace = startTrace(`device:diffState`, { deviceId: this.deviceId })
-		const commandsToAchieveState: Array<any> = this._diffStates(oldHttpSendState, newHttpSendState)
-		this.emit('timeTrace', endTrace(diffTrace))
-
-		// clear any queued commands later than this time:
-		this._doOnTime.clearQueueNowAndAfter(previousStateTime)
-		// add the new commands to the queue:
-		this._addToQueue(commandsToAchieveState, newState.time)
-
-		// store the new state, for later use:
-		this.setState(newState, newState.time)
-	}
-	clearFuture(clearAfterTime: number) {
-		// Clear any scheduled commands after this time
-		this._doOnTime.clearQueueAfter(clearAfterTime)
-	}
-	async terminate() {
-		this._doOnTime.dispose()
-		return Promise.resolve(true)
-	}
-	getStatus(): DeviceStatus {
-		// Good, since this device has no status, really
+	getStatus(): Omit<DeviceStatus, 'active'> {
 		return {
 			statusCode: StatusCode.GOOD,
 			messages: [],
-			active: this.isActive,
 		}
 	}
-	async makeReady(okToDestroyStuff?: boolean): Promise<void> {
-		if (okToDestroyStuff) {
-			if (this._makeReadyDoesReset) {
-				await this.resync()
+
+	actions: Record<string, (id: HttpSendActions, payload?: Record<string, any>) => Promise<ActionExecutionResult>> = {
+		[HttpSendActions.SendCommand]: async (_id: HttpSendActions.SendCommand, payload?: SendCommandPayload) =>
+			this.sendManualCommand(payload),
+	}
+
+	private async sendManualCommand(cmd?: SendCommandPayload): Promise<ActionExecutionResult> {
+		if (!cmd)
+			return {
+				result: ActionExecutionResultCode.Error,
+				response: t('Failed to send command: Missing upayloadrl'),
 			}
-
-			for (const cmd of this._makeReadyCommands || []) {
-				await this.sendCommand(cmd)
-			}
-		}
-	}
-
-	private async resync(): Promise<ActionExecutionResult> {
-		this.clearStates()
-		this._doOnTime.clearQueueAfter(0)
-
-		return {
-			result: ActionExecutionResultCode.Ok,
-		}
-	}
-
-	private async sendCommand(cmd: SendCommandPayload): Promise<ActionExecutionResult> {
-		const time = this.getCurrentTime()
 		if (!cmd.url) {
 			return {
 				result: ActionExecutionResultCode.Error,
@@ -174,157 +96,112 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 			}
 		}
 
-		await this._commandReceiver(time, cmd as HTTPSendCommandContent, 'makeReady', '')
+		await this.sendCommand({
+			tlObjId: '',
+			context: 'makeReady',
+			command: {
+				commandName: 'manual',
+				content: cmd as HTTPSendCommandContent,
+				layer: '',
+			},
+		})
 
 		return {
 			result: ActionExecutionResultCode.Ok,
 		}
 	}
-	async executeAction(
-		actionId: HttpSendActions,
-		payload?: Record<string, any> | undefined
-	): Promise<ActionExecutionResult> {
-		switch (actionId) {
-			case HttpSendActions.SendCommand:
-				return this.sendCommand(payload as SendCommandPayload)
-			case HttpSendActions.Resync:
-				return this.resync()
-			default:
-				return actionNotFoundMessage(actionId)
-		}
-	}
 
-	get canConnect(): boolean {
-		return false
-	}
-	get connected(): boolean {
-		return false
-	}
-	convertStateToHttpSend(state: Timeline.TimelineState<TSRTimelineContent>) {
-		// convert the timeline state into something we can use
-		// (won't even use this.mapping)
+	convertTimelineStateToDeviceState(state: Timeline.TimelineState<TSRTimelineContent>): HttpSendDeviceState {
 		return state
 	}
-	get deviceType() {
-		return DeviceType.HTTPSEND
-	}
-	get deviceName(): string {
-		return 'HTTP-Send ' + this.deviceId
-	}
-	get queue() {
-		return this._doOnTime.getQueue()
-	}
-	/**
-	 * Add commands to queue, to be executed at the right time
-	 */
-	private _addToQueue(commandsToAchieveState: Array<Command>, time: number) {
-		_.each(commandsToAchieveState, (cmd: Command) => {
-			// add the new commands to the queue:
-			this._doOnTime.queue(
-				time,
-				cmd.content.queueId,
-				async (cmd: Command) => {
-					if (cmd.commandName === 'added' || cmd.commandName === 'changed') {
-						this.activeLayers.set(cmd.layer, JSON.stringify(cmd.content))
-						return this._commandReceiver(time, cmd.content, cmd.context, cmd.timelineObjId, cmd.layer)
-					} else {
-						this.activeLayers.delete(cmd.layer)
-						return null
-					}
-				},
-				cmd
-			)
-		})
-	}
-	/**
-	 * Compares the new timeline-state with the old one, and generates commands to account for the difference
-	 */
-	private _diffStates(oldhttpSendState: HTTPSendState, newhttpSendState: HTTPSendState): Array<Command> {
-		// in this httpSend class, let's just cheat:
+	diffStates(oldState: HttpSendDeviceState | undefined, newState: HttpSendDeviceState): Array<HttpSendDeviceCommand> {
+		const commands: Array<HttpSendDeviceCommand> = []
 
-		const commands: Array<Command> = []
-
-		_.each(newhttpSendState.layers, (newLayer, layerKey: string) => {
-			const oldLayer = oldhttpSendState.layers[layerKey]
+		_.each(newState.layers, (newLayer, layerKey: string) => {
+			const oldLayer = oldState?.layers[layerKey]
 			if (!oldLayer) {
 				// added!
 				commands.push({
-					timelineObjId: newLayer.id,
-					commandName: 'added',
-					content: newLayer.content as HTTPSendCommandContent,
+					tlObjId: newLayer.id,
 					context: `added: ${newLayer.id}`,
-					layer: layerKey,
+					command: {
+						commandName: 'added',
+						content: newLayer.content as HTTPSendCommandContent,
+						layer: layerKey,
+					},
 				})
 			} else {
 				// changed?
 				if (!_.isEqual(oldLayer.content, newLayer.content)) {
 					// changed!
 					commands.push({
-						timelineObjId: newLayer.id,
-						commandName: 'changed',
-						content: newLayer.content as HTTPSendCommandContent,
+						tlObjId: newLayer.id,
 						context: `changed: ${newLayer.id} (previously: ${oldLayer.id})`,
-						layer: layerKey,
+						command: {
+							commandName: 'changed',
+							content: newLayer.content as HTTPSendCommandContent,
+							layer: layerKey,
+						},
 					})
 				}
 			}
 		})
 		// removed
-		_.each(oldhttpSendState.layers, (oldLayer, layerKey) => {
-			const newLayer = newhttpSendState.layers[layerKey]
+		_.each(oldState?.layers ?? {}, (oldLayer, layerKey) => {
+			const newLayer = newState.layers[layerKey]
 			if (!newLayer) {
 				// removed!
 				commands.push({
-					timelineObjId: oldLayer.id,
-					commandName: 'removed',
-					content: oldLayer.content as HTTPSendCommandContent,
+					tlObjId: oldLayer.id,
 					context: `removed: ${oldLayer.id}`,
-					layer: layerKey,
+					command: { commandName: 'removed', content: oldLayer.content as HTTPSendCommandContent, layer: layerKey },
 				})
 			}
 		})
 
-		commands.sort((a, b) => a.layer.localeCompare(b.layer))
+		commands.sort((a, b) => a.command.layer.localeCompare(b.command.layer))
 		commands.sort((a, b) => {
-			return (a.content.temporalPriority || 0) - (b.content.temporalPriority || 0)
+			return (a.command.content.temporalPriority || 0) - (b.command.content.temporalPriority || 0)
 		})
 
 		return commands
 	}
+	async sendCommand({ tlObjId, context, command }: HttpSendDeviceCommand): Promise<any> {
+		if (command.commandName === 'added' || command.commandName === 'changed') {
+			this.activeLayers.set(command.layer, JSON.stringify(command.content))
+		} else if (command.commandName === 'removed') {
+			this.activeLayers.delete(command.layer)
+		}
 
-	private async _defaultCommandReceiver(
-		_time: number,
-		cmd: HTTPSendCommandContent,
-		context: CommandContext,
-		timelineObjId: string,
-		layer?: string
-	): Promise<void> {
-		if (layer) {
-			const hash = this.activeLayers.get(layer)
-			if (JSON.stringify(cmd) !== hash) return Promise.resolve() // command is no longer relevant to state
+		if (command.layer) {
+			const hash = this.activeLayers.get(command.layer)
+			if (JSON.stringify(command.content) !== hash) return Promise.resolve() // command is no longer relevant to state
 		}
+
 		const cwc: CommandWithContext = {
-			context: context,
-			command: cmd,
-			timelineObjId: timelineObjId,
+			context,
+			command,
+			tlObjId,
 		}
-		this.emitDebug(cwc)
+		this.emit('debug', { context, tlObjId, command })
 
 		const t = Date.now()
-		debug(`${cmd.type}: ${cmd.url} ${JSON.stringify(cmd.params)} (${timelineObjId})`)
 
-		const httpReq = got[cmd.type]
+		const httpReq = got[command.content.type]
 		try {
 			const options: OptionsOfTextResponseBody = {
-				headers: cmd.headers,
+				dnsCache: this.cacheable,
+				retry: 0,
+				headers: command.content.headers,
 			}
 
-			const params = 'params' in cmd && !_.isEmpty(cmd.params) ? cmd.params : undefined
+			const params =
+				'params' in command.content && !_.isEmpty(command.content.params) ? command.content.params : undefined
 			if (params) {
-				if (cmd.type === TimelineContentTypeHTTP.GET) {
+				if (command.content.type === TimelineContentTypeHTTP.GET) {
 					options.searchParams = params as Record<string, any>
 				} else {
-					if (cmd.paramsType === TimelineContentTypeHTTPParamType.FORM) {
+					if (command.content.paramsType === TimelineContentTypeHTTPParamType.FORM) {
 						options.form = params
 					} else {
 						// Default is json:
@@ -333,25 +210,28 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 				}
 			}
 
-			const response = await httpReq(cmd.url, options)
+			const response = await httpReq(command.content.url, options)
 
 			if (response.statusCode === 200) {
-				this.emitDebug(
-					`HTTPSend: ${cmd.type}: Good statuscode response on url "${cmd.url}": ${response.statusCode} (${context})`
+				this.emit(
+					'debug',
+					`HTTPSend: ${command.content.type}: Good statuscode response on url "${command.content.url}": ${response.statusCode} (${context})`
 				)
 			} else {
-				debug(`Bad response for ${cmd.url}: ${response.statusCode}`)
 				this.emit(
 					'warning',
-					`HTTPSend: ${cmd.type}: Bad statuscode response on url "${cmd.url}": ${response.statusCode} (${context})`
+					`HTTPSend: ${command.content.type}: Bad statuscode response on url "${command.content.url}": ${response.statusCode} (${context})`
 				)
 			}
 		} catch (error) {
 			const err = error as RequestError // make typescript happy
 
-			this.emit('error', `HTTPSend.response error on ${cmd.type} "${cmd.url}" (${context})`, err)
+			this.emit(
+				'error',
+				`HTTPSend.response error on ${command.content.type} "${command.content.url}" (${context})`,
+				err
+			)
 			this.emit('commandError', err, cwc)
-			debug(`Failed ${cmd.url}: ${error} (${timelineObjId})`)
 
 			if ('code' in err) {
 				const retryCodes = [
@@ -366,10 +246,18 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 					'EAI_AGAIN',
 				]
 
-				if (retryCodes.includes(err.code) && this._resendTime) {
-					const timeLeft = Math.max(this._resendTime - (Date.now() - t), 0)
-					await new Promise<void>((resolve) => setTimeout(() => resolve(), timeLeft))
-					this._defaultCommandReceiver(_time, cmd, context, timelineObjId, layer).catch(() => null) // errors will be emitted
+				if (retryCodes.includes(err.code) && this.options?.resendTime) {
+					const timeLeft = Math.max(this.options.resendTime - (Date.now() - t), 0)
+					setTimeout(() => {
+						this.sendCommand({
+							tlObjId,
+							context,
+							command: {
+								...command,
+								commandName: 'retry',
+							},
+						}).catch(() => null) // errors will be emitted
+					}, timeLeft)
 				}
 			}
 		}

--- a/packages/timeline-state-resolver/src/service/devices.ts
+++ b/packages/timeline-state-resolver/src/service/devices.ts
@@ -1,6 +1,7 @@
 import { OscDevice } from '../integrations/osc'
 import { DeviceType } from 'timeline-state-resolver-types'
 import { Device } from './device'
+import { HTTPSendDevice } from '../integrations/httpSend'
 
 export interface DeviceEntry {
 	deviceClass: new () => Device<any, any, any>
@@ -9,7 +10,7 @@ export interface DeviceEntry {
 	executionMode: (options: any) => 'salvo' | 'sequential'
 }
 
-type ImplementedDeviceTypes = DeviceType.OSC
+type ImplementedDeviceTypes = DeviceType.OSC | DeviceType.HTTPSEND
 
 // TODO - move all device implementations here and remove the old Device classes
 export const DevicesDict: Record<ImplementedDeviceTypes, DeviceEntry> = {
@@ -18,5 +19,11 @@ export const DevicesDict: Record<ImplementedDeviceTypes, DeviceEntry> = {
 		canConnect: true,
 		deviceName: (deviceId: string) => 'OSC ' + deviceId,
 		executionMode: () => 'salvo',
+	},
+	[DeviceType.HTTPSEND]: {
+		deviceClass: HTTPSendDevice,
+		canConnect: false,
+		deviceName: (deviceId: string) => 'HTTP ' + deviceId,
+		executionMode: () => 'sequential', // todo - config?
 	},
 }

--- a/packages/timeline-state-resolver/src/service/remoteDeviceInstance.ts
+++ b/packages/timeline-state-resolver/src/service/remoteDeviceInstance.ts
@@ -125,11 +125,11 @@ export class RemoteDeviceInstance<
 		getCurrentTime: () => number,
 		threadConfig?: ThreadedClassConfig
 	): Promise<RemoteDeviceInstance<TOptions>> {
-		if (process.env.JEST_WORKER_ID !== undefined && threadConfig && threadConfig.disableMultithreading) {
-			// running in Jest test environment.
-			// hack: we need to work around the mangling performed by threadedClass, as getCurrentTime needs to not return a promise
-			getCurrentTime = { inner: getCurrentTime } as any
-		}
+		// if (process.env.JEST_WORKER_ID !== undefined && threadConfig && threadConfig.disableMultithreading) {
+		// 	// running in Jest test environment.
+		// 	// hack: we need to work around the mangling performed by threadedClass, as getCurrentTime needs to not return a promise
+		// 	getCurrentTime = { inner: getCurrentTime } as any
+		// }
 
 		const container = new RemoteDeviceInstance(deviceOptions, threadConfig)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11366,6 +11366,7 @@ asn1@evs-broadcast/node-asn1:
     "@tv2media/v-connection": ^7.3.0
     atem-connection: 2.4.0
     atem-state: ^0.12.2
+    cacheable-lookup: ^5.0.3
     casparcg-connection: ^6.0.3
     casparcg-state: ^3.0.2
     debug: ^4.3.4


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)

No DNS cache

* **What is the new behavior (if this is a feature change)?**

Requests are cached, respecting the TTL of the records.

* **Other information**:

Also updates the HTTP send device to the new format