### PR TITLE
fix(vmix): fix scenario where the media load retry system would load clips into playlists twice

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vmix.ts
@@ -9,9 +9,9 @@ export interface VMixOptions {
 	host: string
 	port: number
 	/**
-	 * How often, in milliseconds, to try re-sending certain failed commands. Defaults to 10 seconds. Set to 0 to disable. As of June 9th, 2023, this only works for media loading commands.
+	 * How often, in milliseconds, for when we should poll vMix to query its actual state. Used to know when to re-send certain failed commands.
 	 */
-	retryInterval?: number
+	pollInterval?: number
 }
 
 export interface MappingVmixProgram {

--- a/packages/timeline-state-resolver/src/integrations/vmix/$schemas/options.json
+++ b/packages/timeline-state-resolver/src/integrations/vmix/$schemas/options.json
@@ -11,10 +11,10 @@
 			"type": "integer",
 			"ui:title": "Port"
 		},
-		"retryInterval": {
+		"pollInterval": {
 			"type": "number",
 			"ui:title": "Retry Interval",
-			"description": "How often, in milliseconds, to try re-sending certain failed commands. Defaults to 10 seconds. Set to 0 to disable. As of June 9th, 2023, this only works for media loading commands."
+			"description": "How often, in milliseconds, for when we should poll vMix to query its actual state. Used to know when to re-send certain failed commands."
 		}
 	},
 	"required": ["host", "port"],

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
@@ -2714,6 +2714,7 @@ describe('vMix', () => {
 				options: {
 					host: '127.0.0.1',
 					port: 9999,
+					pollInterval: 0,
 				},
 				commandReceiver: commandReceiver0,
 			}),
@@ -2818,6 +2819,7 @@ describe('vMix', () => {
 				options: {
 					host: '127.0.0.1',
 					port: 9999,
+					pollInterval: 0,
 				},
 				commandReceiver: commandReceiver0,
 			}),
@@ -2942,6 +2944,7 @@ describe('vMix', () => {
 				options: {
 					host: '127.0.0.1',
 					port: 9999,
+					pollInterval: 0,
 				},
 				commandReceiver: commandReceiver0,
 			}),
@@ -3020,6 +3023,7 @@ describe('vMix', () => {
 				options: {
 					host: '127.0.0.1',
 					port: 9999,
+					pollInterval: 0,
 				},
 				commandReceiver: commandReceiver0,
 			}),
@@ -3120,6 +3124,7 @@ describe('vMix', () => {
 				options: {
 					host: '127.0.0.1',
 					port: 9999,
+					pollInterval: 0,
 				},
 				commandReceiver: commandReceiver0,
 			}),
@@ -3221,6 +3226,7 @@ describe('vMix', () => {
 				options: {
 					host: '127.0.0.1',
 					port: 9999,
+					pollInterval: 0,
 				},
 				commandReceiver: commandReceiver0,
 			}),
@@ -3339,6 +3345,7 @@ describe('vMix', () => {
 				options: {
 					host: '127.0.0.1',
 					port: 9999,
+					pollInterval: 0,
 				},
 				commandReceiver: commandReceiver0,
 			}),
@@ -3467,6 +3474,7 @@ describe('vMix', () => {
 				options: {
 					host: '127.0.0.1',
 					port: 9999,
+					pollInterval: 0,
 				},
 				commandReceiver: commandReceiver0,
 			}),

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmixAPI.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmixAPI.spec.ts
@@ -74,6 +74,11 @@ describe('vMixAPI', () => {
 						panY: 0,
 						zoom: 1,
 					},
+					listFilePaths: undefined,
+					name: 'Cam 1',
+					overlays: undefined,
+					playing: true,
+					solo: false,
 				},
 				'2': {
 					number: 2,
@@ -92,6 +97,11 @@ describe('vMixAPI', () => {
 						panY: 0,
 						zoom: 1,
 					},
+					listFilePaths: undefined,
+					name: 'Cam 2',
+					overlays: undefined,
+					playing: true,
+					solo: false,
 				},
 			},
 			overlays: [

--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -31,6 +31,14 @@ export interface Response {
 	body?: string
 }
 
+/**
+ * This TSR integration polls the state of vMix and merges that into our last-known state.
+ * However, not all state properties can be retried from vMix's API.
+ * Therefore, there are some properties that we must "carry over" from our last-known state, every time.
+ * These are those property keys for the Input state objects.
+ */
+export type InferredPartialInputStateKeys = 'filePath' | 'fade' | 'audioAuto' | 'restart'
+
 export class BaseConnection extends EventEmitter<ConnectionEvents> {
 	private _socket?: Socket
 	private _unprocessedLines: string[] = []
@@ -314,7 +322,7 @@ export class VMix extends BaseConnection {
 			edition: xmlState['vmix']['edition']['_text'],
 			inputs: _.indexBy(
 				(xmlState['vmix']['inputs']['input'] as Array<any>).map(
-					(input): Required<Omit<VMixInput, 'filePath' | 'fade' | 'audioAuto' | 'restart'>> => {
+					(input): Required<Omit<VMixInput, InferredPartialInputStateKeys>> => {
 						fixedInputsCount++
 
 						let fixedListFilePaths: VMixInput['listFilePaths'] = undefined

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -1309,6 +1309,11 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 	 * Polls vMix's XML status endpoint, which will change our tracked state based on the response.
 	 */
 	private _pollVmix() {
+		// Testing this sytem is currently unsupported.
+		// Supporting it may require making a more complex vMix mock
+		// that actually changes the XML it reports, instead of being a static thing
+		// that does not react to incoming commands.
+		if (process.env.NODE_ENV === 'test') return
 		clearTimeout(this._pollTimeout)
 		if (this._pollTime) {
 			this._pollTimeout = setTimeout(() => this._pollVmix(), this._pollTime)

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -1309,11 +1309,6 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 	 * Polls vMix's XML status endpoint, which will change our tracked state based on the response.
 	 */
 	private _pollVmix() {
-		// Testing this sytem is currently unsupported.
-		// Supporting it may require making a more complex vMix mock
-		// that actually changes the XML it reports, instead of being a static thing
-		// that does not react to incoming commands.
-		if (process.env.NODE_ENV === 'test') return
 		clearTimeout(this._pollTimeout)
 		if (this._pollTime) {
 			this._pollTimeout = setTimeout(() => this._pollVmix(), this._pollTime)

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -1239,7 +1239,12 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 		context: CommandContext,
 		timelineObjId: string
 	): Promise<any> {
-		// do not poll or retry while we are sending commands, instead always do it closely after:
+		// Do not poll or retry while we are sending commands, instead always do it closely after.
+		// This is potentially an issue while producing a show, because it is theoretically possible
+		// that the operator keeps performing actions/takes within 5 seconds of one another and
+		// therefore this timeout keeps getting reset and never expires.
+		// For now, we classify this as an extreme outlier edge case and acknowledge that this system
+		// does not support it.
 		clearTimeout(this._pollTimeout)
 		if (this._pollTime) this._pollTimeout = setTimeout(() => this._pollVmix(), BACKOFF_VMIX_POLL_INTERVAL)
 


### PR DESCRIPTION
This PR is being opened on behalf of TV 2 Norge.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix and feature, kind of.

* **What is the current behavior?** (You can also link to an open issue here)

Under common conditions, the existing system to retry loading missing media will add that media to List Inputs (aka playlists) exactly twice, resulting in bad behavior in playout.

* **What is the new behavior (if this is a feature change)?**

This PR completely changes the mechanism used for this system. Instead of detecting failed commands, we instead poll the state of vMix and use that to determine how different the real state of vMix is from our expected state. This difference is then used to generate new commands, same as any other state update.

* **Other information**:

As a side effect of this, more things than just media retrying will be present. Other commands that have failed unexpectedly may also get retried. This could have unforeseen consequences. This approach must be thought about carefully and alternatives or modifications should be considered before merging.

I'll be honest, some of this feels gross to me and I want there to be a better way, but maybe there isn't one (because vMix's API is... limiting.)