### PR TITLE
feat: atem audio routing control SOFIE-2512

### DIFF
--- a/packages/timeline-state-resolver-types/src/atem.ts
+++ b/packages/timeline-state-resolver-types/src/atem.ts
@@ -15,6 +15,7 @@ export enum MappingAtemType {
 	SuperSourceProperties,
 	AudioChannel,
 	MacroPlayer,
+	AudioRouting,
 }
 
 export enum AtemMediaPoolType {
@@ -44,6 +45,7 @@ export enum TimelineContentTypeAtem { //  Atem-state
 	MEDIAPLAYER = 'mp',
 	AUDIOCHANNEL = 'audioChan',
 	MACROPLAYER = 'macroPlayer',
+	AUDIOROUTING = 'audioRouting',
 }
 
 export enum AtemTransitionStyle { // Note: copied from atem-state
@@ -120,6 +122,8 @@ export type TimelineContentAtemAny =
 	| TimelineContentAtemMacroPlayer
 	| TimelineContentAtemAudioChannel
 	| TimelineContentAtemMediaPlayer
+	| TimelineContentAtemAudioRouting
+
 export interface TimelineContentAtemBase {
 	deviceType: DeviceType.ATEM
 	type: TimelineContentTypeAtem
@@ -350,5 +354,11 @@ export interface TimelineContentAtemMacroPlayer extends TimelineContentAtemBase 
 		macroIndex: number
 		isRunning: boolean
 		loop?: boolean
+	}
+}
+export interface TimelineContentAtemAudioRouting extends TimelineContentAtemBase {
+	type: TimelineContentTypeAtem.AUDIOROUTING
+	audioRouting: {
+		sourceId: number
 	}
 }

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -90,8 +90,8 @@
 	],
 	"dependencies": {
 		"@tv2media/v-connection": "^7.3.0",
-		"atem-connection": "2.4.0",
-		"atem-state": "^0.12.2",
+		"atem-connection": "2.5.0",
+		"atem-state": "0.12.3-nightly-v0-x-20230808-125421-d138a13.0",
 		"casparcg-connection": "^6.0.0",
 		"casparcg-state": "^3.0.2",
 		"debug": "^4.3.1",

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -91,7 +91,7 @@
 	"dependencies": {
 		"@tv2media/v-connection": "^7.3.0",
 		"atem-connection": "2.5.0",
-		"atem-state": "0.12.3-nightly-v0-x-20230808-125421-d138a13.0",
+		"atem-state": "0.13.0",
 		"casparcg-connection": "^6.0.0",
 		"casparcg-state": "^3.0.2",
 		"debug": "^4.3.1",

--- a/packages/timeline-state-resolver/src/integrations/atem/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/index.ts
@@ -314,6 +314,33 @@ export class AtemDevice extends DeviceWithState<DeviceState, DeviceOptionsAtemIn
 								}
 							}
 							break
+
+						case MappingAtemType.AudioRouting:
+							if (content.type === TimelineContentTypeAtem.AUDIOROUTING) {
+								// lazily generate the state properties, to make this be opt in per-mapping
+								if (!deviceState.fairlight)
+									deviceState.fairlight = {
+										inputs: {},
+									}
+								if (!deviceState.fairlight.audioRouting)
+									deviceState.fairlight.audioRouting = {
+										sources: {},
+										outputs: {},
+									}
+
+								deviceState.fairlight.audioRouting.outputs[mapping.index] = {
+									// readonly props, they won't be diffed
+									audioOutputId: mapping.index,
+									audioChannelPair: 0,
+									externalPortType: 0,
+									internalPortType: 0,
+
+									// mutable props
+									name: `Output ${mapping.index}`,
+									...content.audioRouting,
+								}
+							}
+							break
 					}
 				}
 

--- a/packages/timeline-state-resolver/src/integrations/atem/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/index.ts
@@ -443,16 +443,12 @@ export class AtemDevice extends DeviceWithState<DeviceState, DeviceOptionsAtemIn
 			}
 		}
 
-		return _.map(this._state.diffStates(oldAtemState, newAtemState), (cmd: any) => {
-			if (_.has(cmd, 'command') && _.has(cmd, 'context')) {
-				return cmd as AtemCommandWithContext
-			} else {
-				// backwards compability, to be removed later:
-				return {
-					command: cmd as AtemCommands.ISerializableCommand,
-					context: null,
-					timelineObjId: '', // @todo: implement in Atem-state
-				}
+		const diffCommands = this._state.diffStates(oldAtemState, newAtemState)
+		return diffCommands.map((cmd) => {
+			return {
+				command: cmd,
+				context: null,
+				timelineObjId: '', // @todo: implement in Atem-state
 			}
 		})
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,10 +2375,10 @@ atem-connection@2.5.0:
     tslib "^1.13.0"
     wavefile "^8.4.4"
 
-atem-state@0.12.3-nightly-v0-x-20230808-125421-d138a13.0:
-  version "0.12.3-nightly-v0-x-20230808-125421-d138a13.0"
-  resolved "https://registry.yarnpkg.com/atem-state/-/atem-state-0.12.3-nightly-v0-x-20230808-125421-d138a13.0.tgz#a8c72f6c5ac10e977b4618d705f24e68f548b2dd"
-  integrity sha512-+hnH5/MsH8Upu1RrVFQ4CoKOTAM9IyYC6sh5PQM9on1Sv8LaxPbiK69l9rmEC21DzvKktBgxOVtshSSTsXSZnQ==
+atem-state@0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/atem-state/-/atem-state-0.13.0.tgz#07f6452364550cc2af0c9ddfdf1ffe40010e81c9"
+  integrity sha512-uEzt15vP8c155OfsyuWrkbxb3PKoLBpy4Q7WAlqx2t4AZTGSbHCpQz8YIx/9Zg9zPw9bDLt8eVUJBp30QYLp8Q==
   dependencies:
     deepmerge "^4.2.2"
     tslib "^2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2362,10 +2362,10 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-atem-connection@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/atem-connection/-/atem-connection-2.4.0.tgz#bcaf5713e6a3f64be45583bf98b0c294255b7f86"
-  integrity sha512-/D+fWWRrCcxzfCbSdUMT00nCR/S8xCwFTSE6oqFkFSb0mtxgCORs8WKMF0KZddPPuUU2S/4ZfR+Oh53Hm/d/jQ==
+atem-connection@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/atem-connection/-/atem-connection-2.5.0.tgz#dceb616595af37d0b3c118d0a9e6f613f1a2d419"
+  integrity sha512-JZI0B9jfw91ALSx4hOQH8Mk5TGQuJcK1/tdHQDIvoPW+z7qOds2JPlxNHkk5Thg5pLVKBgMHxIXDWfQ5vHPw8w==
   dependencies:
     big-integer "^1.6.51"
     eventemitter3 "^4.0.4"
@@ -2375,10 +2375,10 @@ atem-connection@2.4.0:
     tslib "^1.13.0"
     wavefile "^8.4.4"
 
-atem-state@^0.12.2:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/atem-state/-/atem-state-0.12.2.tgz#40a97b77d32ed9effee5e99505193d1e0c94deca"
-  integrity sha512-4OFp3HHpvhmcBHOpx7M/8Gjpf1xUkH5GZZGdPJGQt3N9JOZggONbC7ndoko4qhwapl7EQkM2eMhkI+uDAKj8LQ==
+atem-state@0.12.3-nightly-v0-x-20230808-125421-d138a13.0:
+  version "0.12.3-nightly-v0-x-20230808-125421-d138a13.0"
+  resolved "https://registry.yarnpkg.com/atem-state/-/atem-state-0.12.3-nightly-v0-x-20230808-125421-d138a13.0.tgz#a8c72f6c5ac10e977b4618d705f24e68f548b2dd"
+  integrity sha512-+hnH5/MsH8Upu1RrVFQ4CoKOTAM9IyYC6sh5PQM9on1Sv8LaxPbiK69l9rmEC21DzvKktBgxOVtshSSTsXSZnQ==
   dependencies:
     deepmerge "^4.2.2"
     tslib "^2.3.1"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the new behavior (if this is a feature change)?**

Allow for controlling the audio routing in the ATEM TVS HD8.  
Only the outpts with a mapping and timeline object on the layer will be controlled

* **Other information**:

This has not been tested against a compatible atem, but the network traffic has been looked at against a different model