### PR TITLE
feat(sisyfos): Send fadeTime with faderLevel if specified

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
@@ -712,6 +712,7 @@ describe('Sisyfos', () => {
 							mappedLayer: 'sisyfos_channel_2',
 							faderLevel: 0.2,
 							isPgm: 0,
+							fadeTime: 500,
 						},
 					],
 					overridePriority: -999,
@@ -762,6 +763,7 @@ describe('Sisyfos', () => {
 						{
 							mappedLayer: 'sisyfos_channel_2',
 							faderLevel: 0.74,
+							fadeTime: 500,
 						},
 					],
 					overridePriority: -999,
@@ -775,12 +777,12 @@ describe('Sisyfos', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			type: 'setFader',
 			channel: 1,
-			value: 0.1,
+			values: [0.1],
 		})
 		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			type: 'setFader',
 			channel: 2,
-			value: 0.2,
+			values: [0.2, 500],
 		})
 		commandReceiver0.mockClear()
 
@@ -800,7 +802,7 @@ describe('Sisyfos', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			type: 'togglePgm',
 			channel: 2,
-			values: [1],
+			values: [1, 500],
 		})
 		commandReceiver0.mockClear()
 
@@ -810,12 +812,12 @@ describe('Sisyfos', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			type: 'setFader',
 			channel: 1,
-			value: 0.75,
+			values: [0.75],
 		})
 		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			type: 'setFader',
 			channel: 2,
-			value: 0.74,
+			values: [0.74, 500],
 		})
 		commandReceiver0.mockClear()
 
@@ -825,17 +827,17 @@ describe('Sisyfos', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			type: 'setFader',
 			channel: 1,
-			value: 0.1,
+			values: [0.1],
 		})
 		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			type: 'togglePgm',
 			channel: 2,
-			values: [0],
+			values: [0, 500],
 		})
 		expect(getMockCall(commandReceiver0, 2, 1)).toMatchObject({
 			type: 'setFader',
 			channel: 2,
-			value: 0.2,
+			values: [0.2, 500],
 		})
 
 		commandReceiver0.mockClear()

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -74,109 +74,115 @@ export class SisyfosApi extends EventEmitter {
 			this._oscClient.send({ address: '/clearpst', args: [] })
 		} else if (command.type === SisyfosCommandType.LABEL) {
 			this._oscClient.send({
-				address: `/ch/${(command as StringCommand).channel + 1}/label`,
+				address: `/ch/${command.channel + 1}/label`,
 				args: [
 					{
 						type: 's',
-						value: (command as StringCommand).value,
+						value: command.value,
 					},
 				],
 			})
 		} else if (command.type === SisyfosCommandType.TOGGLE_PGM) {
-			const args: Array<MetaArgument> = (command as ValuesCommand).values.map((value) => {
+			const args: Array<MetaArgument> = command.values.map((value) => {
 				return {
 					type: 'i',
 					value,
 				}
 			})
 			this._oscClient.send({
-				address: `/ch/${(command as ValuesCommand).channel + 1}/pgm`,
+				address: `/ch/${command.channel + 1}/pgm`,
 				args,
 			})
 		} else if (command.type === SisyfosCommandType.TOGGLE_PST) {
 			this._oscClient.send({
-				address: `/ch/${(command as ValueCommand).channel + 1}/pst`,
+				address: `/ch/${command.channel + 1}/pst`,
 				args: [
 					{
 						type: 'i',
-						value: (command as ValueCommand).value,
+						value: command.value,
 					},
 				],
 			})
 		} else if (command.type === SisyfosCommandType.SET_FADER) {
-			const args: Array<MetaArgument> = (command as ValuesCommand).values.map((value) => {
+			const args: Array<MetaArgument> = command.values.map((value) => {
 				return {
 					type: 'f',
 					value,
 				}
 			})
 			this._oscClient.send({
-				address: `/ch/${(command as ValueCommand).channel + 1}/faderlevel`,
+				address: `/ch/${command.channel + 1}/faderlevel`,
 				args,
 			})
 		} else if (command.type === SisyfosCommandType.VISIBLE) {
 			this._oscClient.send({
-				address: `/ch/${(command as ValueCommand).channel + 1}/visible`,
+				address: `/ch/${command.channel + 1}/visible`,
 				args: [
 					{
 						type: 'i',
-						value: (command as ValueCommand).value,
+						value: command.value === true ? 1 : 0,
 					},
 				],
 			})
 		} else if (command.type === SisyfosCommandType.SET_CHANNEL) {
-			if ((command as SetChannelCommand).values.label) {
+			if (command.values.label) {
 				this._oscClient.send({
-					address: `/ch/${(command as StringCommand).channel + 1}/label`,
+					address: `/ch/${command.channel + 1}/label`,
 					args: [
 						{
 							type: 's',
-							value: (command as SetChannelCommand).values.label as string,
+							value: command.values.label,
 						},
 					],
 				})
 			}
-			if ((command as SetChannelCommand).values.pgmOn !== undefined) {
+			if (command.values.pgmOn !== undefined) {
 				this._oscClient.send({
-					address: `/ch/${(command as ValueCommand).channel + 1}/pgm`,
+					address: `/ch/${command.channel + 1}/pgm`,
 					args: [
 						{
 							type: 'i',
-							value: (command as SetChannelCommand).values.pgmOn as number,
+							value: command.values.pgmOn,
 						},
 					],
 				})
 			}
-			if ((command as SetChannelCommand).values.pstOn !== undefined) {
+			if (command.values.pstOn !== undefined) {
 				this._oscClient.send({
-					address: `/ch/${(command as ValueCommand).channel + 1}/pst`,
+					address: `/ch/${command.channel + 1}/pst`,
 					args: [
 						{
 							type: 'i',
-							value: (command as SetChannelCommand).values.pstOn as number,
+							value: command.values.pstOn,
 						},
 					],
 				})
 			}
-			if ((command as SetChannelCommand).values.faderLevel !== undefined) {
-				const args: Array<MetaArgument> = (command as ValuesCommand).values.map((value) => {
-					return {
+			if (command.values.faderLevel !== undefined) {
+				const args: Array<MetaArgument> = [
+					{
 						type: 'f',
-						value,
-					}
-				})
+						value: command.values.faderLevel,
+					},
+				]
+				if (command.values.fadeTime) {
+					args.push({
+						type: 'f',
+						value: command.values.fadeTime,
+					})
+				}
 				this._oscClient.send({
-					address: `/ch/${(command as ValueCommand).channel + 1}/faderlevel`,
+					address: `/ch/${command.channel + 1}/faderlevel`,
 					args,
 				})
 			}
-			if ((command as SetChannelCommand).values.visible !== undefined) {
+			if (command.values.visible !== undefined) {
 				this._oscClient.send({
-					address: `/ch/${(command as ValueCommand).channel + 1}/visible`,
+					address: `/ch/${command.channel + 1}/visible`,
 					args: [
 						{
 							type: 'i',
-							value: (command as SetChannelCommand).values.visible as unknown as number,
+							value: command.values.visible as unknown as number,
 						},
 					],
 				})
@@ -350,7 +356,7 @@ export interface SetChannelCommand {
 	values: Partial<SisyfosAPIChannel>
 }
 
-export interface ChannelCommand {
+export interface ChannelCommand extends BaseCommand {
 	type:
 		| SisyfosCommandType.SET_FADER
 		| SisyfosCommandType.TOGGLE_PGM
@@ -358,7 +364,10 @@ export interface ChannelCommand {
 		| SisyfosCommandType.LABEL
 		| SisyfosCommandType.VISIBLE
 	channel: number
-	value: boolean | number | string
+}
+
+export interface GlobalCommand extends BaseCommand {
+	type: SisyfosCommandType.CLEAR_PST_ROW | SisyfosCommandType.TAKE | SisyfosCommandType.RESYNC
 }
 
 export interface BoolCommand extends ChannelCommand {
@@ -366,11 +375,11 @@ export interface BoolCommand extends ChannelCommand {
 	value: boolean
 }
 export interface ValueCommand extends ChannelCommand {
-	type: SisyfosCommandType.TOGGLE_PGM | SisyfosCommandType.TOGGLE_PST | SisyfosCommandType.SET_FADER
+	type: SisyfosCommandType.TOGGLE_PST | SisyfosCommandType.VISIBLE
 	value: number
 }
 
-export interface ValuesCommand extends Omit<ChannelCommand, 'value'> {
+export interface ValuesCommand extends ChannelCommand {
 	type: SisyfosCommandType.TOGGLE_PGM | SisyfosCommandType.SET_FADER
 	values: number[]
 }
@@ -380,17 +389,12 @@ export interface StringCommand extends ChannelCommand {
 	value: string
 }
 
-export interface ResyncCommand extends BaseCommand {
-	type: SisyfosCommandType.RESYNC
-}
-
 export type SisyfosCommand =
-	| BaseCommand
+	| GlobalCommand
 	| ValueCommand
 	| ValuesCommand
 	| BoolCommand
 	| StringCommand
-	| ResyncCommand
 	| SetChannelCommand
 
 export interface SisyfosChannel extends SisyfosAPIChannel {

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -104,14 +104,15 @@ export class SisyfosApi extends EventEmitter {
 				],
 			})
 		} else if (command.type === SisyfosCommandType.SET_FADER) {
+			const args: Array<MetaArgument> = (command as ValuesCommand).values.map((value) => {
+				return {
+					type: 'f',
+					value,
+				}
+			})
 			this._oscClient.send({
 				address: `/ch/${(command as ValueCommand).channel + 1}/faderlevel`,
-				args: [
-					{
-						type: 'f',
-						value: (command as ValueCommand).value,
-					},
-				],
+				args,
 			})
 		} else if (command.type === SisyfosCommandType.VISIBLE) {
 			this._oscClient.send({
@@ -158,14 +159,15 @@ export class SisyfosApi extends EventEmitter {
 				})
 			}
 			if ((command as SetChannelCommand).values.faderLevel !== undefined) {
+				const args: Array<MetaArgument> = (command as ValuesCommand).values.map((value) => {
+					return {
+						type: 'f',
+						value,
+					}
+				})
 				this._oscClient.send({
 					address: `/ch/${(command as ValueCommand).channel + 1}/faderlevel`,
-					args: [
-						{
-							type: 'f',
-							value: (command as SetChannelCommand).values.faderLevel as number,
-						},
-					],
+					args,
 				})
 			}
 			if ((command as SetChannelCommand).values.visible !== undefined) {
@@ -369,7 +371,7 @@ export interface ValueCommand extends ChannelCommand {
 }
 
 export interface ValuesCommand extends Omit<ChannelCommand, 'value'> {
-	type: SisyfosCommandType.TOGGLE_PGM
+	type: SisyfosCommandType.TOGGLE_PGM | SisyfosCommandType.SET_FADER
 	values: number[]
 }
 

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -536,13 +536,17 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 
 			if (oldChannel && oldChannel.faderLevel !== newChannel.faderLevel) {
 				debug(`change faderLevel ${index}: "${newChannel.faderLevel}"`)
+				const values: number[] = [newChannel.faderLevel]
+				if (newChannel.fadeTime) {
+					values.push(newChannel.fadeTime)
+				}
 				commands.push({
 					context: 'faderLevel change',
 					content: {
 						type: SisyfosCommandType.SET_FADER,
 						channel: Number(index),
-						value: newChannel.faderLevel,
-					},
+						values,
+					} as ValuesCommand,
 					timelineObjId: newChannel.tlObjIds[0] || '',
 				})
 			}

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -22,14 +22,7 @@ import {
 
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
 
-import {
-	SisyfosApi,
-	SisyfosCommand,
-	SisyfosState,
-	SisyfosChannel,
-	SisyfosCommandType,
-	ValuesCommand,
-} from './connection'
+import { SisyfosApi, SisyfosCommand, SisyfosState, SisyfosChannel, SisyfosCommandType } from './connection'
 import Debug from 'debug'
 import { startTrace, endTrace, actionNotFoundMessage } from '../../lib'
 const debug = Debug('timeline-state-resolver:sisyfos')
@@ -516,7 +509,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 						type: SisyfosCommandType.TOGGLE_PGM,
 						channel: Number(index),
 						values,
-					} as ValuesCommand,
+					},
 					timelineObjId: newChannel.tlObjIds[0] || '',
 				})
 			}
@@ -546,7 +539,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 						type: SisyfosCommandType.SET_FADER,
 						channel: Number(index),
 						values,
-					} as ValuesCommand,
+					},
 					timelineObjId: newChannel.tlObjIds[0] || '',
 				})
 			}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature (sisyfos)


* **What is the current behavior?** (You can also link to an open issue here)
Sisyfos cannot change fade time if the fader `isPgm` value isn't changed, so level changes cannot have adjustable fade time.


* **What is the new behavior (if this is a feature change)?**
In conjunction with https://github.com/tv2/sisyfos-audio-controller/pull/271 the `fadeTime` property is sent with level changes.


* **Other information**:
Tested against an unmodified version of Sisyfos (4.18.0) and appears to have no ill effects so should be fine to be in TSR until the Sisyfos PR is merged.