### PR TITLE
Proxy support for the HTTPSend device

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/generated/httpSend.ts
@@ -10,6 +10,18 @@ export interface HTTPSendOptions {
 	 * Minimum time in ms before a command is resent, set to <= 0 or undefined to disable
 	 */
 	resendTime?: number
+	/**
+	 * HTTP Proxy
+	 */
+	httpProxy?: string
+	/**
+	 * HTTPS Proxy
+	 */
+	httpsProxy?: string
+	/**
+	 * URLs not to use a proxy for (E.G. github.com)
+	 */
+	noProxy?: string[]
 }
 
 export type SomeMappingHttpSend = Record<string, never>

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -99,6 +99,7 @@
 		"emberplus-connection": "^0.1.2",
 		"eventemitter3": "^4.0.7",
 		"got": "^11.8.6",
+		"hpagent": "^1.2.0",
 		"hyperdeck-connection": "^0.5.0",
 		"klona": "^2.0.6",
 		"obs-websocket-js": "^4.0.3",

--- a/packages/timeline-state-resolver/src/integrations/httpSend/$schemas/options.json
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/$schemas/options.json
@@ -9,6 +9,25 @@
 			"ui:description": "Minimum time in ms before a command is resent, set to a number > 0 to enable",
 			"ui:title": "Resend time in ms",
 			"default": 0
+		},
+		"httpProxy": {
+			"type": "string",
+			"description": "HTTP Proxy",
+			"ui:title": "HTTP Proxy address"
+		},
+		"httpsProxy": {
+			"type": "string",
+			"description": "HTTPS Proxy",
+			"ui:title": "HTTPS Proxy address"
+		},
+		"noProxy": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"description": "URLs not to use a proxy for (E.G. github.com)",
+			"ui:description": "URLs that shouldn't be accessed via a proxy (E.G. github.com)",
+			"ui:title": "No proxy"
 		}
 	},
 	"required": [],

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -16,6 +16,7 @@ import {
 import _ = require('underscore')
 import got, { OptionsOfTextResponseBody, RequestError } from 'got'
 import { t } from '../../lib'
+import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent'
 import CacheableLookup from 'cacheable-lookup'
 
 export type HttpSendDeviceState = Timeline.TimelineState<TSRTimelineContent>
@@ -197,6 +198,23 @@ export class HTTPSendDevice
 				dnsCache: this.cacheable,
 				retry: 0,
 				headers: command.content.headers,
+			}
+
+			const url = new URL(command.content.url)
+			if (!this.options.noProxy?.includes(url.host)) {
+				if (url.protocol === 'http:' && this.options.httpProxy) {
+					options.agent = {
+						http: new HttpProxyAgent({
+							proxy: this.options.httpProxy,
+						}),
+					}
+				} else if (url.protocol === 'https:' && this.options.httpsProxy) {
+					options.agent = {
+						https: new HttpsProxyAgent({
+							proxy: this.options.httpsProxy,
+						}),
+					}
+				}
 			}
 
 			const params =

--- a/yarn.lock
+++ b/yarn.lock
@@ -5821,6 +5821,13 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
+"hpagent@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "hpagent@npm:1.2.0"
+  checksum: b029da695edae438cee4da2a437386f9db4ac27b3ceb7306d02e1b586c9c194741ed2e943c8a222e0cfefaf27ee3f863aca7ba1721b0950a2a19bf25bc0d85e2
+  languageName: node
+  linkType: hard
+
 "html-escaper@npm:^2.0.0":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
@@ -11374,6 +11381,7 @@ asn1@evs-broadcast/node-asn1:
     emberplus-connection: ^0.1.2
     eventemitter3: ^4.0.7
     got: ^11.8.6
+    hpagent: ^1.2.0
     hyperdeck-connection: ^0.5.0
     i18next-conv: ^13.1.1
     i18next-parser: ^6.6.0


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?** (You can also link to an open issue here)
HTTP Requests that require a proxy fail

* **What is the new behavior (if this is a feature change)?**
HTTP Requests that require a proxy succeed.
~~An optional global request timeout is introduced.~~ Removed because it's causing errors even when requests suceed

* **Other information**:
Reference implementation: https://github.com/sindresorhus/got/blob/main/documentation/tips.md#proxying