### PR TITLE
fix: resync chef on reconnect (SOFIE-2544)

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/sofieChef/api.ts
+++ b/packages/timeline-state-resolver/src/integrations/sofieChef/api.ts
@@ -13,6 +13,7 @@ export type ReceiveWSMessageAny =
 	| ReceiveWSMessageRestart
 	| ReceiveWSMessageStop
 	| ReceiveWSMessageExecute
+	| ReceiveWSMessageList
 
 export interface ReceiveWSMessageBase {
 	type: ReceiveWSMessageType
@@ -25,6 +26,7 @@ export enum ReceiveWSMessageType {
 	RESTART = 'restart',
 	STOP = 'stop',
 	EXECUTE = 'execute',
+	LIST = 'list',
 }
 
 export interface ReceiveWSMessagePlayURL extends ReceiveWSMessageBase {
@@ -47,6 +49,17 @@ export interface ReceiveWSMessageExecute extends ReceiveWSMessageBase {
 	type: ReceiveWSMessageType.EXECUTE
 	windowId: string
 	jsCode: string
+}
+export interface ReceiveWSMessageList extends ReceiveWSMessageBase {
+	type: ReceiveWSMessageType.LIST
+}
+export interface APIResponseList extends APIResponse {
+	list: {
+		id: string
+		url: string | null
+		statusCode: string
+		statusMessage: string
+	}[]
 }
 
 export type SendWSMessageAny = SendWSMessageReply | SendWSMessageStatus
@@ -83,4 +96,14 @@ export enum StatusCode {
 export interface StatusObject {
 	statusCode: StatusCode
 	message: string
+}
+
+export enum IpcMethods {
+	// Note: update this enum in lib/preload.ts when changed
+	ReportStatus = 'ReportStatus',
+}
+
+export interface ReportStatusIpcPayload {
+	status: StatusCode
+	message?: string
 }

--- a/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
@@ -413,7 +413,9 @@ export class SofieChefDevice extends DeviceWithState<SofieChefState, DeviceOptio
 
 				// Is it in the mappings?
 				// We should only touch stuff that is in our mappings:
-				const foundMapping = Object.values(newMappings).find((mapping) => mapping.options.windowId === windowId)
+				const foundMapping = Object.values<Mapping<SomeMappingSofieChef>>(newMappings).find(
+					(mapping) => mapping.options.windowId === windowId
+				)
 
 				if (foundMapping) {
 					commands.push({

--- a/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
@@ -8,7 +8,6 @@ import {
 	SomeMappingSofieChef,
 	TSRTimelineContent,
 	Timeline,
-	Mapping,
 	ActionExecutionResult,
 	ActionExecutionResultCode,
 	SofieChefActions,
@@ -162,7 +161,7 @@ export class SofieChefDevice extends DeviceWithState<SofieChefState, DeviceOptio
 				})
 		}, RECONNECT_WAIT_TIME)
 	}
-	async resyncState() {
+	private async resyncState() {
 		const response = (await this._sendMessage({
 			msgId: 0, // set later
 			type: ReceiveWSMessageType.LIST,
@@ -205,7 +204,7 @@ export class SofieChefDevice extends DeviceWithState<SofieChefState, DeviceOptio
 
 		const newSofieChefState = this.convertStateToSofieChef(newState, newMappings)
 
-		const commandsToAchieveState: Array<Command> = this._diffStates(oldSofieChefState, newSofieChefState, newMappings)
+		const commandsToAchieveState: Array<Command> = this._diffStates(oldSofieChefState, newSofieChefState)
 
 		// clear any queued commands later than this time:
 		this._doOnTime.clearQueueNowAndAfter(previousStateTime)
@@ -365,11 +364,7 @@ export class SofieChefDevice extends DeviceWithState<SofieChefState, DeviceOptio
 	/**
 	 * Compares the new timeline-state with the old one, and generates commands to account for the difference
 	 */
-	private _diffStates(
-		oldSofieChefState: SofieChefState,
-		newSofieChefState: SofieChefState,
-		newMappings: Mappings<SomeMappingSofieChef>
-	) {
+	private _diffStates(oldSofieChefState: SofieChefState, newSofieChefState: SofieChefState) {
 		const commands: Command[] = []
 
 		// Added / Changed things:
@@ -411,23 +406,15 @@ export class SofieChefDevice extends DeviceWithState<SofieChefState, DeviceOptio
 			if (!newWindow) {
 				// Removed
 
-				// Is it in the mappings?
-				// We should only touch stuff that is in our mappings:
-				const foundMapping = Object.values<Mapping<SomeMappingSofieChef>>(newMappings).find(
-					(mapping) => mapping.options.windowId === windowId
-				)
-
-				if (foundMapping) {
-					commands.push({
-						context: 'removed',
-						timelineObjId: oldWindow.urlTimelineObjId,
-						content: {
-							msgId: 0, // set later
-							type: ReceiveWSMessageType.STOP,
-							windowId: windowId,
-						},
-					})
-				}
+				commands.push({
+					context: 'removed',
+					timelineObjId: oldWindow.urlTimelineObjId,
+					content: {
+						msgId: 0, // set later
+						type: ReceiveWSMessageType.STOP,
+						windowId: windowId,
+					},
+				})
 			}
 		}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Functionality fix


* **What is the current behavior?** (You can also link to an open issue here)
If Sofie Chef goes offline and then comes back, there will be no resync of state, so Chef will continue to display the default url.


* **What is the new behavior (if this is a feature change)?**
Upon a reconnect, TSR resynct the state and sends new commands.


* **Other information**:

This PR depends on https://github.com/nrkno/sofie-chef/pull/6
