### PR TITLE
Sisyfos device would not garbage collect (Sofie 2576)

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/atem/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/index.ts
@@ -143,6 +143,10 @@ export class AtemDevice extends DeviceWithState<DeviceState, DeviceOptionsAtemIn
 				.catch(() => {
 					resolve(false)
 				})
+				.finally(() => {
+					this._atem.destroy().catch(() => null)
+					this._atem.removeAllListeners()
+				})
 		})
 	}
 

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -164,11 +164,15 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			if (!this._ccg) {
 				resolve(true)
 				return
-			}
-			this._ccg.disconnect()
-			this._ccg.onDisconnected = () => {
-				resolve(true)
+			} else if (!this._ccg.connected) {
+				this._ccg.onDisconnected = () => {
+					resolve(true)
+					this._ccg.removeAllListeners()
+				}
+				this._ccg.disconnect()
+			} else {
 				this._ccg.removeAllListeners()
+				resolve(true)
 			}
 		})
 	}

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -168,6 +168,7 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			this._ccg.disconnect()
 			this._ccg.onDisconnected = () => {
 				resolve(true)
+				this._ccg.removeAllListeners()
 			}
 		})
 	}

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -111,6 +111,7 @@ export class HTTPSendDevice extends DeviceWithState<HTTPSendState, DeviceOptions
 	}
 	async terminate() {
 		this._doOnTime.dispose()
+		this.activeLayers.clear()
 		return Promise.resolve(true)
 	}
 	getStatus(): DeviceStatus {

--- a/packages/timeline-state-resolver/src/integrations/osc/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/osc/index.ts
@@ -154,6 +154,8 @@ export class OSCMessageDevice extends DeviceWithState<OSCDeviceState, DeviceOpti
 	}
 	async terminate() {
 		this._doOnTime.dispose()
+		this._oscClient.close()
+		this._oscClient.removeAllListeners()
 		return Promise.resolve(true)
 	}
 	getStatus(): DeviceStatus {

--- a/packages/timeline-state-resolver/src/integrations/shotoku/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/shotoku/index.ts
@@ -125,6 +125,7 @@ export class ShotokuDevice extends DeviceWithState<ShotokuDeviceState, DeviceOpt
 	}
 	async terminate() {
 		this._doOnTime.dispose()
+		await this._shotoku.dispose()
 		return Promise.resolve(true)
 	}
 	getStatus(): DeviceStatus {

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -31,7 +31,7 @@ export class SisyfosApi extends EventEmitter {
 
 		this._oscClient = new osc.UDPPort({
 			localAddress: '0.0.0.0',
-			localPort: 5256, // To avoid not using the same port both ways on local installs, this port is one higher
+			localPort: 0, // Random port
 			remoteAddress: this.host,
 			remotePort: this.port,
 			metadata: true,

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -152,6 +152,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 	async terminate() {
 		this._doOnTime.dispose()
 		this._sisyfos.dispose()
+		this._sisyfos.removeAllListeners()
 		return Promise.resolve(true)
 	}
 	getStatus(): DeviceStatus {

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -151,6 +151,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 	}
 	async terminate() {
 		this._doOnTime.dispose()
+		this._sisyfos.dispose()
 		return Promise.resolve(true)
 	}
 	getStatus(): DeviceStatus {

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
@@ -144,6 +144,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 	async terminate(): Promise<boolean> {
 		if (this._vizmseManager) {
 			await this._vizmseManager.terminate()
+			this._vizmseManager.removeAllListeners()
 			delete this._vizmseManager
 		}
 		this._doOnTime.dispose()

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -243,6 +243,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 	async terminate() {
 		this._doOnTime.dispose()
 		await this._vmix.dispose()
+		this._vmix.removeAllListeners()
 		return Promise.resolve(true)
 	}
 


### PR DESCRIPTION
When a device is terminated it should be ready for garbage collection. A lot of devices don't seem to do this very well, this isn't a problem when ran in multi threaded mode because the thread can be restarted but in single threaded mode can cause issues.

In addition the sisyfos device used a fixed local port which is unnecessary and prevented us from running multiple connections (combined with the above this caused connection instability)