### PR TITLE
fix: remove unused casparcg useScheduling option

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/casparCG.ts
+++ b/packages/timeline-state-resolver-types/src/generated/casparCG.ts
@@ -25,10 +25,6 @@ export interface CasparCGOptions {
 	 * Interval (ms) for retrying to load media that previously failed. (-1 disables, 0 uses the default interval)
 	 */
 	retryInterval?: number
-	/**
-	 * whether to use the CasparCG-SCHEDULE command to run future commands, or the internal (backwards-compatible) command queue
-	 */
-	useScheduling?: boolean
 }
 
 export interface MappingCasparCGLayer {

--- a/packages/timeline-state-resolver/examples/testChangeTimelineQuickly.ts
+++ b/packages/timeline-state-resolver/examples/testChangeTimelineQuickly.ts
@@ -13,7 +13,6 @@ const a = async function () {
 	await tsr.addDevice('casparcg0', {
 		type: DeviceType.CASPARCG,
 		options: {
-			// useScheduling: true,
 			host: '127.0.0.1',
 			// port: 5250
 		},

--- a/packages/timeline-state-resolver/src/integrations/casparCG/$schemas/options.json
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/$schemas/options.json
@@ -42,12 +42,6 @@
 			"ui:title": "Media retry interval",
 			"ui:description": "Time between retries for media that could not be loaded on first try. Set to -1 to disable.",
 			"default": 0
-		},
-		"useScheduling": {
-			"type": "boolean",
-			"description": "whether to use the CasparCG-SCHEDULE command to run future commands, or the internal (backwards-compatible) command queue",
-			"ui:title": "Use CasparCG Timecode Scheduler",
-			"default": false
 		}
 	},
 	"required": ["host"],

--- a/packages/timeline-state-resolver/src/integrations/casparCG/__tests__/casparcg.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/__tests__/casparcg.spec.ts
@@ -55,7 +55,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -134,7 +133,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -202,7 +200,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: false,
 				fps: 50,
 			},
 			commandReceiver: commandReceiver0,
@@ -285,7 +282,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: false,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -359,7 +355,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -449,7 +444,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -529,7 +523,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -610,7 +603,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -727,7 +719,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -847,7 +838,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -986,7 +976,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -1092,7 +1081,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -1197,7 +1185,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -1298,7 +1285,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -1388,7 +1374,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: true,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -1473,7 +1458,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: false,
 				retryInterval: undefined, // disable retries explicitly, we will manually trigger them
 			},
 			commandReceiver: commandReceiver0,
@@ -1601,7 +1585,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: false,
 				retryInterval: undefined, // disable retries explicitly, we will manually trigger them
 			},
 			commandReceiver: commandReceiver0,
@@ -1731,7 +1714,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: false,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -1828,7 +1810,6 @@ describe('CasparCG', () => {
 			type: DeviceType.CASPARCG,
 			options: {
 				host: '127.0.0.1',
-				useScheduling: false,
 			},
 			commandReceiver: commandReceiver0,
 			skipVirginCheck: true,
@@ -1943,7 +1924,6 @@ describe('CasparCG', () => {
 // 			type: DeviceType.CASPARCG,
 // 			options: {
 // 				host: '127.0.0.1',
-// 				useScheduling: false,
 // 				retryInterval: undefined, // disable retries explicitly, we will manually trigger them
 // 			},
 // 			commandReceiver: commandReceiver0,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix

* **What is the current behavior?** (You can also link to an open issue here)

The option `useScheduling` for the casparcg device is not used in the code, as it appears to be no longer supported by casparcg-connection

* **What is the new behavior (if this is a feature change)?**

Option is removed

* **Other information**:
