### PR TITLE
fix: casparcg restart action always responds 'OK' SOFIE-2588

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -671,10 +671,7 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			case CasparCGActions.ClearAllChannels:
 				return this.clearAllChannels()
 			case CasparCGActions.RestartServer:
-				await this.restartCasparCG()
-				return {
-					result: ActionExecutionResultCode.Ok,
-				}
+				return this.restartCasparCG()
 			default:
 				return {
 					result: ActionExecutionResultCode.Error,
@@ -703,27 +700,28 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			}
 		}
 
-		return new Promise<ActionExecutionResult>((resolve) => {
-			const url = `http://${this.initOptions?.launcherHost}:${this.initOptions?.launcherPort}/processes/${this.initOptions?.launcherProcess}/restart`
-			got
-				.post(url)
-				.then((response) => {
-					if (response.statusCode === 200) {
-						resolve({ result: ActionExecutionResultCode.Ok })
-					} else {
-						resolve({
-							result: ActionExecutionResultCode.Error,
-							response: t('Bad reply: [{{statusCode}}] {{body}}', {
-								statusCode: response.statusCode,
-								body: response.body,
-							}),
-						})
+		const url = `http://${this.initOptions?.launcherHost}:${this.initOptions?.launcherPort}/processes/${this.initOptions?.launcherProcess}/restart`
+		return got
+			.post(url)
+			.then((response) => {
+				if (response.statusCode === 200) {
+					return { result: ActionExecutionResultCode.Ok }
+				} else {
+					return {
+						result: ActionExecutionResultCode.Error,
+						response: t('Bad reply: [{{statusCode}}] {{body}}', {
+							statusCode: response.statusCode,
+							body: response.body,
+						}),
 					}
-				})
-				.catch((error) => {
-					resolve({ result: ActionExecutionResultCode.Error, response: error })
-				})
-		})
+				}
+			})
+			.catch((error) => {
+				return {
+					result: ActionExecutionResultCode.Error,
+					response: error.toString(),
+				}
+			})
 	}
 	getStatus(): DeviceStatus {
 		let statusCode = StatusCode.GOOD

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -702,7 +702,11 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 
 		const url = `http://${this.initOptions?.launcherHost}:${this.initOptions?.launcherPort}/processes/${this.initOptions?.launcherProcess}/restart`
 		return got
-			.post(url)
+			.post(url, {
+				timeout: {
+					request: 5000, // Arbitary, long enough for realistic scenarios
+				},
+			})
 			.then((response) => {
 				if (response.statusCode === 200) {
 					return { result: ActionExecutionResultCode.Ok }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix

* **What is the current behavior?** (You can also link to an open issue here)

When issuing a restart command for a casparcg device, it will always respond 'OK', even when the request or the config is invalid.

Once fixed, if the request failed because of a network error, the error would often be `{}`. It is now explicitly `toString()`, to ensure something json safe is sent back to the caller

* **Other information**:

There was also an unnecessary wrapping of the request with `new Promise`. This looks to have been left behind when request was replaced with got.