### PR TITLE
feat: improve QuickTSR logging

### DIFF
--- a/packages/quick-tsr/src/tsrHandler.ts
+++ b/packages/quick-tsr/src/tsrHandler.ts
@@ -150,6 +150,13 @@ export class TSRHandler {
 			await device.device.on('slowCommand', ((_info: SlowSentCommandInfo) => {
 				// console.log(`Device ${device.deviceId} slow command: ${_info}`)
 			}) as () => void)
+			await device.device.on('commandReport', ((command: any) => {
+				console.log(`Device ${device.deviceId} command: ${JSON.stringify(command)}`)
+			}) as () => void)
+			await device.device.on('debug', (...args: any[]) => {
+				const data = args.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg) : arg))
+				console.log(`Device ${device.deviceId} debug: ${data}`)
+			})
 			// also ask for the status now, and update:
 			// onConnectionChanged(await device.device.getStatus())
 		} catch (e) {

--- a/packages/quick-tsr/src/tsrHandler.ts
+++ b/packages/quick-tsr/src/tsrHandler.ts
@@ -145,7 +145,7 @@ export class TSRHandler {
 			this._devices[deviceId] = device
 
 			await device.device.on('connectionChanged', ((status: DeviceStatus) => {
-				console.log(`Device ${device.deviceId} status changed: ${status}`)
+				console.log(`Device ${device.deviceId} status changed: ${JSON.stringify(status)}`)
 			}) as () => void)
 			await device.device.on('slowCommand', ((_info: SlowSentCommandInfo) => {
 				// console.log(`Device ${device.deviceId} slow command: ${_info}`)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Small improvements in QuickTSR (no production code changes for consumers of the actual library, so maybe it's more of a chore than a feat?)


* **What is the current behavior?** (You can also link to an open issue here)
Device status is logged as `[object Object]`. No debug and command logs when enabled for devices


* **What is the new behavior (if this is a feature change)?**
Device status is stringified. Command report and debug logging work when enabled with `reportAllCommands: true` and `debug: true` respectively.


* **Other information**:
Opened towards release49, but I can change that if needed.