### PR TITLE
Action return types

### DIFF
--- a/packages/quick-tsr/src/index.ts
+++ b/packages/quick-tsr/src/index.ts
@@ -128,6 +128,10 @@ function reloadInput(changed?: { path: string; stats: fs.Stats }) {
 				currentInput.timeline = []
 
 				await tsr.setDevices(newInput.devices)
+
+				setTimeout(() => {
+					tsr.logMediaList().catch(console.error)
+				}, 1000)
 			}
 
 			if (

--- a/packages/quick-tsr/src/tsrHandler.ts
+++ b/packages/quick-tsr/src/tsrHandler.ts
@@ -10,7 +10,12 @@ import {
 	SlowSentCommandInfo,
 	DeviceOptionsBase,
 	SlowFulfilledCommandInfo,
+	DeviceType,
+	CasparCGDevice,
+	CasparCGActions,
+	ActionExecutionResultCode,
 } from 'timeline-state-resolver'
+import { ThreadedClass } from 'threadedclass'
 
 import * as _ from 'underscore'
 import { TSRSettings } from './index'
@@ -83,6 +88,25 @@ export class TSRHandler {
 	async destroy(): Promise<void> {
 		if (this.tsr) return this.tsr.destroy()
 		else return Promise.resolve()
+	}
+	async logMediaList(): Promise<void> {
+		for (const deviceContainer of this.tsr.getDevices()) {
+			if (deviceContainer.deviceType === DeviceType.CASPARCG) {
+				const device = deviceContainer.device as ThreadedClass<CasparCGDevice>
+
+				console.log(`Fetching media list for ${device.deviceId}...`)
+
+				const list = await device.executeAction(CasparCGActions.ListMedia, undefined)
+
+				if (list.result === ActionExecutionResultCode.Error) {
+					console.log(`Error fetching media list: ${list.response?.key}`)
+				} else if (list.result === ActionExecutionResultCode.Ok) {
+					console.log(`Media list:`)
+					if (!list.resultData) return
+					console.log(list.resultData.map((m) => `${m.clip} ${m.size} ${m.datetime}`))
+				}
+			}
+		}
 	}
 	setTimelineAndMappings(tl: TSRTimeline, mappings: Mappings): void {
 		// this._timeline = tl

--- a/packages/timeline-state-resolver-types/src/generated/abstract.ts
+++ b/packages/timeline-state-resolver-types/src/generated/abstract.ts
@@ -4,11 +4,21 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface AbstractOptions {}
 
 export type SomeMappingAbstract = Record<string, never>
 
 export enum AbstractActions {
-	TestAction = 'testAction',
+	TestAction = 'testAction'
 }
+export interface AbstractActionExecutionResults {
+	testAction: () => void
+}
+export type AbstractActionExecutionPayload<A extends keyof AbstractActionExecutionResults> = Parameters<
+	AbstractActionExecutionResults[A]
+>[0]
+
+export type AbstractActionExecutionResult<A extends keyof AbstractActionExecutionResults> =
+	ActionExecutionResult<ReturnType<AbstractActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/generated/action-schema.ts
+++ b/packages/timeline-state-resolver-types/src/generated/action-schema.ts
@@ -29,5 +29,5 @@ export interface TSRActionSchema {
 	/**
 	 * Defines the returned data
 	 */
-	returnData?: undefined
+	result?: undefined
 }

--- a/packages/timeline-state-resolver-types/src/generated/action-schema.ts
+++ b/packages/timeline-state-resolver-types/src/generated/action-schema.ts
@@ -26,4 +26,8 @@ export interface TSRActionSchema {
 	 * The payload object is the first argument of the function
 	 */
 	payload?: string
+	/**
+	 * Defines the returned data
+	 */
+	returnData?: undefined
 }

--- a/packages/timeline-state-resolver-types/src/generated/atem.ts
+++ b/packages/timeline-state-resolver-types/src/generated/atem.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface AtemOptions {
 	host: string
@@ -81,5 +82,14 @@ export enum MappingAtemType {
 export type SomeMappingAtem = MappingAtemMixEffect | MappingAtemDownStreamKeyer | MappingAtemSuperSourceBox | MappingAtemAuxilliary | MappingAtemMediaPlayer | MappingAtemSuperSourceProperties | MappingAtemAudioChannel | MappingAtemMacroPlayer | MappingAtemAudioRouting
 
 export enum AtemActions {
-	Resync = 'resync',
+	Resync = 'resync'
 }
+export interface AtemActionExecutionResults {
+	resync: () => void
+}
+export type AtemActionExecutionPayload<A extends keyof AtemActionExecutionResults> = Parameters<
+	AtemActionExecutionResults[A]
+>[0]
+
+export type AtemActionExecutionResult<A extends keyof AtemActionExecutionResults> =
+	ActionExecutionResult<ReturnType<AtemActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/generated/casparCG.ts
+++ b/packages/timeline-state-resolver-types/src/generated/casparCG.ts
@@ -41,13 +41,28 @@ export enum MappingCasparCGType {
 
 export type SomeMappingCasparCG = MappingCasparCGLayer
 
+export interface ListMediaPayload {
+	subDirectory?: string
+}
+
+export type ListMediaReturnData = {
+	clip: string
+	type: 'MOVIE' | 'STILL' | 'AUDIO'
+	size: number
+	dateTime: number
+	frames: number
+	framerate: number
+}[]
+
 export enum CasparCGActions {
 	ClearAllChannels = 'clearAllChannels',
-	RestartServer = 'restartServer'
+	RestartServer = 'restartServer',
+	ListMedia = 'listMedia'
 }
 export interface CasparCGActionExecutionResults {
 	clearAllChannels: () => void,
-	restartServer: () => void
+	restartServer: () => void,
+	listMedia: (payload: ListMediaPayload) => ListMediaReturnData
 }
 export type CasparCGActionExecutionPayload<A extends keyof CasparCGActionExecutionResults> = Parameters<
 	CasparCGActionExecutionResults[A]

--- a/packages/timeline-state-resolver-types/src/generated/casparCG.ts
+++ b/packages/timeline-state-resolver-types/src/generated/casparCG.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface CasparCGOptions {
 	/**
@@ -42,5 +43,15 @@ export type SomeMappingCasparCG = MappingCasparCGLayer
 
 export enum CasparCGActions {
 	ClearAllChannels = 'clearAllChannels',
-	RestartServer = 'restartServer',
+	RestartServer = 'restartServer'
 }
+export interface CasparCGActionExecutionResults {
+	clearAllChannels: () => void,
+	restartServer: () => void
+}
+export type CasparCGActionExecutionPayload<A extends keyof CasparCGActionExecutionResults> = Parameters<
+	CasparCGActionExecutionResults[A]
+>[0]
+
+export type CasparCGActionExecutionResult<A extends keyof CasparCGActionExecutionResults> =
+	ActionExecutionResult<ReturnType<CasparCGActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/generated/casparCG.ts
+++ b/packages/timeline-state-resolver-types/src/generated/casparCG.ts
@@ -49,7 +49,7 @@ export type ListMediaResult = {
 	clip: string
 	type: 'MOVIE' | 'STILL' | 'AUDIO'
 	size: number
-	dateTime: number
+	datetime?: number
 	frames: number
 	framerate: number
 }[]

--- a/packages/timeline-state-resolver-types/src/generated/casparCG.ts
+++ b/packages/timeline-state-resolver-types/src/generated/casparCG.ts
@@ -45,7 +45,7 @@ export interface ListMediaPayload {
 	subDirectory?: string
 }
 
-export type ListMediaReturnData = {
+export type ListMediaResult = {
 	clip: string
 	type: 'MOVIE' | 'STILL' | 'AUDIO'
 	size: number
@@ -62,7 +62,7 @@ export enum CasparCGActions {
 export interface CasparCGActionExecutionResults {
 	clearAllChannels: () => void,
 	restartServer: () => void,
-	listMedia: (payload: ListMediaPayload) => ListMediaReturnData
+	listMedia: (payload: ListMediaPayload) => ListMediaResult
 }
 export type CasparCGActionExecutionPayload<A extends keyof CasparCGActionExecutionResults> = Parameters<
 	CasparCGActionExecutionResults[A]

--- a/packages/timeline-state-resolver-types/src/generated/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/generated/httpSend.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface HTTPSendOptions {
 	/**
@@ -56,5 +57,15 @@ export enum TimelineContentTypeHTTPParamType {
 
 export enum HttpSendActions {
 	Resync = 'resync',
-	SendCommand = 'sendCommand',
+	SendCommand = 'sendCommand'
 }
+export interface HttpSendActionExecutionResults {
+	resync: () => void,
+	sendCommand: (payload: HTTPSendCommandContent) => void
+}
+export type HttpSendActionExecutionPayload<A extends keyof HttpSendActionExecutionResults> = Parameters<
+	HttpSendActionExecutionResults[A]
+>[0]
+
+export type HttpSendActionExecutionResult<A extends keyof HttpSendActionExecutionResults> =
+	ActionExecutionResult<ReturnType<HttpSendActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/generated/hyperdeck.ts
+++ b/packages/timeline-state-resolver-types/src/generated/hyperdeck.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface HyperdeckOptions {
 	host: string
@@ -27,5 +28,15 @@ export type SomeMappingHyperdeck = MappingHyperdeckTransport
 
 export enum HyperdeckActions {
 	FormatDisks = 'formatDisks',
-	Resync = 'resync',
+	Resync = 'resync'
 }
+export interface HyperdeckActionExecutionResults {
+	formatDisks: () => void,
+	resync: () => void
+}
+export type HyperdeckActionExecutionPayload<A extends keyof HyperdeckActionExecutionResults> = Parameters<
+	HyperdeckActionExecutionResults[A]
+>[0]
+
+export type HyperdeckActionExecutionResult<A extends keyof HyperdeckActionExecutionResults> =
+	ActionExecutionResult<ReturnType<HyperdeckActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/generated/quantel.ts
+++ b/packages/timeline-state-resolver-types/src/generated/quantel.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface QuantelOptions {
 	/**
@@ -61,5 +62,15 @@ export type SomeMappingQuantel = MappingQuantelPort
 
 export enum QuantelActions {
 	RestartGateway = 'restartGateway',
-	ClearStates = 'clearStates',
+	ClearStates = 'clearStates'
 }
+export interface QuantelActionExecutionResults {
+	restartGateway: () => void,
+	clearStates: () => void
+}
+export type QuantelActionExecutionPayload<A extends keyof QuantelActionExecutionResults> = Parameters<
+	QuantelActionExecutionResults[A]
+>[0]
+
+export type QuantelActionExecutionResult<A extends keyof QuantelActionExecutionResults> =
+	ActionExecutionResult<ReturnType<QuantelActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
+++ b/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface SisyfosOptions {
 	host: string
@@ -34,5 +35,14 @@ export enum MappingSisyfosType {
 export type SomeMappingSisyfos = MappingSisyfosChannel | MappingSisyfosChannelByLabel | MappingSisyfosChannels
 
 export enum SisyfosActions {
-	Reinit = 'reinit',
+	Reinit = 'reinit'
 }
+export interface SisyfosActionExecutionResults {
+	reinit: () => void
+}
+export type SisyfosActionExecutionPayload<A extends keyof SisyfosActionExecutionResults> = Parameters<
+	SisyfosActionExecutionResults[A]
+>[0]
+
+export type SisyfosActionExecutionResult<A extends keyof SisyfosActionExecutionResults> =
+	ActionExecutionResult<ReturnType<SisyfosActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/generated/sofieChef.ts
+++ b/packages/timeline-state-resolver-types/src/generated/sofieChef.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface SofieChefOptions {
 	/**
@@ -33,5 +34,15 @@ export interface RestartWindowPayload {
 
 export enum SofieChefActions {
 	RestartAllWindows = 'restartAllWindows',
-	RestartWindow = 'restartWindow',
+	RestartWindow = 'restartWindow'
 }
+export interface SofieChefActionExecutionResults {
+	restartAllWindows: () => void,
+	restartWindow: (payload: RestartWindowPayload) => void
+}
+export type SofieChefActionExecutionPayload<A extends keyof SofieChefActionExecutionResults> = Parameters<
+	SofieChefActionExecutionResults[A]
+>[0]
+
+export type SofieChefActionExecutionResult<A extends keyof SofieChefActionExecutionResults> =
+	ActionExecutionResult<ReturnType<SofieChefActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/generated/tcpSend.ts
+++ b/packages/timeline-state-resolver-types/src/generated/tcpSend.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface TCPSendOptions {
 	host: string
@@ -47,5 +48,16 @@ export interface SendTcpCommandPayload {
 export enum TcpSendActions {
 	Reconnect = 'reconnect',
 	ResetState = 'resetState',
-	SendTcpCommand = 'sendTcpCommand',
+	SendTcpCommand = 'sendTcpCommand'
 }
+export interface TcpSendActionExecutionResults {
+	reconnect: () => void,
+	resetState: () => void,
+	sendTcpCommand: (payload: SendTcpCommandPayload) => void
+}
+export type TcpSendActionExecutionPayload<A extends keyof TcpSendActionExecutionResults> = Parameters<
+	TcpSendActionExecutionResults[A]
+>[0]
+
+export type TcpSendActionExecutionResult<A extends keyof TcpSendActionExecutionResults> =
+	ActionExecutionResult<ReturnType<TcpSendActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/generated/vizMSE.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vizMSE.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface VizMSEOptions {
 	/**
@@ -79,5 +80,16 @@ export interface ActivatePayload {
 export enum VizMSEActions {
 	PurgeRundown = 'purgeRundown',
 	Activate = 'activate',
-	StandDown = 'standDown',
+	StandDown = 'standDown'
 }
+export interface VizMSEActionExecutionResults {
+	purgeRundown: () => void,
+	activate: (payload: ActivatePayload) => void,
+	standDown: () => void
+}
+export type VizMSEActionExecutionPayload<A extends keyof VizMSEActionExecutionResults> = Parameters<
+	VizMSEActionExecutionResults[A]
+>[0]
+
+export type VizMSEActionExecutionResult<A extends keyof VizMSEActionExecutionResults> =
+	ActionExecutionResult<ReturnType<VizMSEActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/generated/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vmix.ts
@@ -4,6 +4,7 @@
  * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
  * and run "yarn generate-schema-types" to regenerate this file.
  */
+import { ActionExecutionResult } from ".."
 
 export interface VMixOptions {
 	host: string
@@ -124,5 +125,16 @@ export interface SavePresetPayload {
 export enum VmixActions {
 	LastPreset = 'lastPreset',
 	OpenPreset = 'openPreset',
-	SavePreset = 'savePreset',
+	SavePreset = 'savePreset'
 }
+export interface VmixActionExecutionResults {
+	lastPreset: () => void,
+	openPreset: (payload: OpenPresetPayload) => void,
+	savePreset: (payload: SavePresetPayload) => void
+}
+export type VmixActionExecutionPayload<A extends keyof VmixActionExecutionResults> = Parameters<
+	VmixActionExecutionResults[A]
+>[0]
+
+export type VmixActionExecutionResult<A extends keyof VmixActionExecutionResults> =
+	ActionExecutionResult<ReturnType<VmixActionExecutionResults[A]>>

--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -160,12 +160,12 @@ export interface Datastore {
 	}
 }
 
-export interface ActionExecutionResult<ReturnData = undefined> {
+export interface ActionExecutionResult<ResultData = undefined> {
 	result: ActionExecutionResultCode
 	/** Response message, intended to be displayed to a user */
 	response?: ITranslatableMessage
 	/** Response data */
-	returnData?: ReturnData
+	resultData?: ResultData
 }
 
 export enum ActionExecutionResultCode {

--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -160,9 +160,12 @@ export interface Datastore {
 	}
 }
 
-export interface ActionExecutionResult {
+export interface ActionExecutionResult<ReturnData = undefined> {
 	result: ActionExecutionResultCode
+	/** Response message, intended to be displayed to a user */
 	response?: ITranslatableMessage
+	/** Response data */
+	returnData?: ReturnData
 }
 
 export enum ActionExecutionResultCode {

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -92,7 +92,7 @@
 		"atem-connection": "2.5.0",
 		"atem-state": "0.13.0",
 		"cacheable-lookup": "^5.0.3",
-		"casparcg-connection": "^6.0.6",
+		"casparcg-connection": "^6.1.1",
 		"casparcg-state": "^3.0.2",
 		"debug": "^4.3.4",
 		"deepmerge": "^4.3.1",

--- a/packages/timeline-state-resolver/scripts/schema-types.mjs
+++ b/packages/timeline-state-resolver/scripts/schema-types.mjs
@@ -95,8 +95,6 @@ for (const dir of dirs) {
 
 	const dirId = capitalise(dir)
 
-	console.log(dirId)
-
 	let output = ''
 
 	const generatedSchemaDirectory = path.join(basePathOfDereferencedShemas, dir)
@@ -194,7 +192,7 @@ for (const dir of dirs) {
 				const actionDefinition = {
 					id: action.id,
 					payloadId: undefined,
-					returnDataId: undefined
+					resultId: undefined
 				}
 				actionDefinitions.push(actionDefinition)
 
@@ -211,9 +209,9 @@ for (const dir of dirs) {
 					}))
 				}
 				// Return Data:
-				if (action.returnData) {
-					actionDefinition.returnDataId = action.returnData.id || capitalise(action.id + 'ReturnData')
-					actionTypes.push(await compile(action.returnData, actionDefinition.returnDataId, {
+				if (action.result) {
+					actionDefinition.resultId = action.result.id || capitalise(action.id + 'Result')
+					actionTypes.push(await compile(action.result, actionDefinition.resultId, {
 						additionalProperties: false,
 						style: PrettierConf,
 						bannerComment: '',
@@ -245,7 +243,7 @@ ${actionDefinitions.map(
 		output += `
 export interface ${dirId}ActionExecutionResults {
 ${actionDefinitions.map(
-			(actionDefinition) => `\t${actionDefinition.id}: (${actionDefinition.payloadId ? `payload: ${actionDefinition.payloadId}` : ''}) => ${actionDefinition.returnDataId || 'void'}`
+			(actionDefinition) => `\t${actionDefinition.id}: (${actionDefinition.payloadId ? `payload: ${actionDefinition.payloadId}` : ''}) => ${actionDefinition.resultId || 'void'}`
 		).join(',\n')}
 }`
 		// Prepend import:

--- a/packages/timeline-state-resolver/src/$schemas/action-schema.json
+++ b/packages/timeline-state-resolver/src/$schemas/action-schema.json
@@ -3,6 +3,9 @@
 	"description": "This is a meta-schema that defines the schemas for *device*/$schemas/actions.json",
 	"type": "object",
 	"properties": {
+		"$schema": {
+			"type": "string"
+		},
 		"actions": {
 			"type": "array",
 			"items": {
@@ -31,13 +34,36 @@
 						"properties": {
 							"type": {
 								"type": "string",
-								"enum": ["object"]
+								"enum": [
+									"object"
+								]
 							},
 							"properties": {
 								"type": "object"
 							}
 						},
-						"required": ["type", "properties"],
+						"required": [
+							"type",
+							"properties"
+						],
+						"allOf": [
+							{
+								"$ref": "https://json-schema.org/draft/2020-12/schema"
+							}
+						]
+					},
+					"returnData": {
+						"type": "object",
+						"tsType": "undefined",
+						"description": "Defines the returned data",
+						"properties": {
+							"type": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"type"
+						],
 						"allOf": [
 							{
 								"$ref": "https://json-schema.org/draft/2020-12/schema"
@@ -45,11 +71,17 @@
 						]
 					}
 				},
-				"required": ["id", "name", "destructive"],
+				"required": [
+					"id",
+					"name",
+					"destructive"
+				],
 				"additionalProperties": false
 			}
 		}
 	},
-	"required": ["actions"],
+	"required": [
+		"actions"
+	],
 	"additionalProperties": false
 }

--- a/packages/timeline-state-resolver/src/$schemas/action-schema.json
+++ b/packages/timeline-state-resolver/src/$schemas/action-schema.json
@@ -52,7 +52,7 @@
 							}
 						]
 					},
-					"returnData": {
+					"result": {
 						"type": "object",
 						"tsType": "undefined",
 						"description": "Defines the returned data",

--- a/packages/timeline-state-resolver/src/__mocks__/casparcg-connection.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/casparcg-connection.ts
@@ -28,7 +28,7 @@ export class BasicCasparCGAPI extends EventEmitter {
 		instances.push(this)
 	}
 
-	async executeCommand(command: AMCPCommand): Promise<SendResult> {
+	async executeCommand(command: AMCPCommand): Promise<SendResult<any>> {
 		mockDo.apply(this, command)
 
 		if (command.command === Commands.Info) {

--- a/packages/timeline-state-resolver/src/devices/device.ts
+++ b/packages/timeline-state-resolver/src/devices/device.ts
@@ -259,7 +259,7 @@ export abstract class Device<TOptions extends DeviceOptionsBase<any>>
 		return this._isActive
 	}
 
-	async executeAction(_actionId: string, _payload?: Record<string, any>): Promise<ActionExecutionResult> {
+	async executeAction(_actionId: string, _payload?: Record<string, any>): Promise<ActionExecutionResult<any>> {
 		return {
 			result: ActionExecutionResultCode.Error,
 			response: t('Device does not implement an action handler'),

--- a/packages/timeline-state-resolver/src/integrations/atem/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/index.ts
@@ -17,6 +17,8 @@ import {
 	ActionExecutionResult,
 	ActionExecutionResultCode,
 	AtemActions,
+	AtemActionExecutionResult,
+	AtemActionExecutionPayload,
 } from 'timeline-state-resolver-types'
 import { AtemState, State as DeviceState, Defaults as StateDefault } from 'atem-state'
 import {
@@ -144,13 +146,14 @@ export class AtemDevice extends DeviceWithState<DeviceState, DeviceOptionsAtemIn
 			result: ActionExecutionResultCode.Ok,
 		}
 	}
-	async executeAction(
-		actionId: AtemActions,
-		_payload?: Record<string, any> | undefined
-	): Promise<ActionExecutionResult> {
+	async executeAction<A extends AtemActions>(
+		actionId0: A,
+		_payload: AtemActionExecutionPayload<A>
+	): Promise<AtemActionExecutionResult<A>> {
+		const actionId = actionId0 as AtemActions // type fix for when there is only a single action
 		switch (actionId) {
 			case AtemActions.Resync:
-				return this.resyncState()
+				return this.resyncState() as Promise<AtemActionExecutionResult<A>>
 			default:
 				return actionNotFoundMessage(actionId)
 		}

--- a/packages/timeline-state-resolver/src/integrations/casparCG/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/$schemas/actions.json
@@ -43,7 +43,7 @@
 						"size": {
 							"type": "number"
 						},
-						"dateTime": {
+						"datetime": {
 							"type": "number"
 						},
 						"frames": {

--- a/packages/timeline-state-resolver/src/integrations/casparCG/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/$schemas/actions.json
@@ -10,6 +10,60 @@
 			"id": "restartServer",
 			"name": "Restart Server",
 			"destructive": true
+		},
+		{
+			"id": "listMedia",
+			"name": "List items in media folder",
+			"destructive": false,
+			"payload": {
+				"type": "object",
+				"properties": {
+					"subDirectory": {
+						"type": "string"
+					}
+				},
+				"additionalProperties": false
+			},
+			"returnData": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"clip": {
+							"type": "string",
+						},
+						"type": {
+							"type": "string",
+							"enum": [
+								"MOVIE",
+								"STILL",
+								"AUDIO"
+							]
+						},
+						"size": {
+							"type": "number"
+						},
+						"dateTime": {
+							"type": "number"
+						},
+						"frames": {
+							"type": "number"
+						},
+						"framerate": {
+							"type": "number"
+						}
+					},
+					"required": [
+						"clip",
+						"type",
+						"size",
+						"dateTime",
+						"frames",
+						"framerate"
+					],
+					"additionalProperties": false
+				}
+			}
 		}
 	]
 }

--- a/packages/timeline-state-resolver/src/integrations/casparCG/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/$schemas/actions.json
@@ -24,7 +24,7 @@
 				},
 				"additionalProperties": false
 			},
-			"returnData": {
+			"result": {
 				"type": "array",
 				"items": {
 					"type": "object",

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -48,7 +48,7 @@ import got from 'got'
 import { InternalTransitionHandler } from '../../devices/transitions/transitionHandler'
 import Debug from 'debug'
 import { actionNotFoundMessage, endTrace, startTrace, t } from '../../lib'
-import { ListMediaReturnData } from 'timeline-state-resolver-types'
+import { ListMediaResult } from 'timeline-state-resolver-types'
 import { ClsParameters } from 'casparcg-connection/dist/parameters'
 const debug = Debug('timeline-state-resolver:casparcg')
 
@@ -734,7 +734,7 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 				}
 			})
 	}
-	private async listMedia(query: ClsParameters = {}): Promise<ActionExecutionResult<ListMediaReturnData>> {
+	private async listMedia(query: ClsParameters = {}): Promise<ActionExecutionResult<ListMediaResult>> {
 		const result = await this._ccg.executeCommand(
 			literal<ClsCommand>({
 				command: Commands.Cls,
@@ -753,7 +753,7 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			// TODO: implement return data
 			return {
 				result: ActionExecutionResultCode.Ok,
-				returnData: [],
+				resultData: [],
 			}
 		} else {
 			return {

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -16,10 +16,12 @@ import {
 	Timeline,
 	TSRTimelineContent,
 	ActionExecutionResult,
+	CasparCGActionExecutionResult,
 	ActionExecutionResultCode,
 	CasparCGActions,
 	MappingCasparCGLayer,
 	Mapping,
+	CasparCGActionExecutionPayload,
 } from 'timeline-state-resolver-types'
 
 import {
@@ -45,7 +47,7 @@ import { DoOnTime, SendMode } from '../../devices/doOnTime'
 import got from 'got'
 import { InternalTransitionHandler } from '../../devices/transitions/transitionHandler'
 import Debug from 'debug'
-import { endTrace, startTrace, t } from '../../lib'
+import { actionNotFoundMessage, endTrace, startTrace, t } from '../../lib'
 const debug = Debug('timeline-state-resolver:casparcg')
 
 const MEDIA_RETRY_INTERVAL = 10 * 1000 // default time in ms between checking whether a file needs to be retried loading
@@ -665,18 +667,17 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			result: ActionExecutionResultCode.Ok,
 		}
 	}
-
-	async executeAction(id: CasparCGActions): Promise<ActionExecutionResult> {
-		switch (id) {
+	async executeAction<A extends CasparCGActions>(
+		actionId: A,
+		_payload: CasparCGActionExecutionPayload<A>
+	): Promise<CasparCGActionExecutionResult<A>> {
+		switch (actionId) {
 			case CasparCGActions.ClearAllChannels:
-				return this.clearAllChannels()
+				return this.clearAllChannels() as Promise<CasparCGActionExecutionResult<A>>
 			case CasparCGActions.RestartServer:
-				return this.restartCasparCG()
+				return this.restartCasparCG() as Promise<CasparCGActionExecutionResult<A>>
 			default:
-				return {
-					result: ActionExecutionResultCode.Error,
-					response: t('Action "{{id}}" not found', { id }),
-				}
+				return actionNotFoundMessage(actionId)
 		}
 	}
 

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -763,8 +763,6 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 		const request = await result.request
 
 		if (request.responseCode === 200) {
-			// TODO: implement return data
-
 			return {
 				result: ActionExecutionResultCode.Ok,
 				resultData: request.data,

--- a/packages/timeline-state-resolver/src/integrations/pharos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/pharos/index.ts
@@ -157,10 +157,8 @@ export class PharosDevice extends DeviceWithState<PharosState, DeviceOptionsPhar
 		return Promise.resolve()
 	}
 	async executeAction(actionId: string, _payload?: Record<string, any> | undefined): Promise<ActionExecutionResult> {
-		switch (actionId) {
-			default:
-				return actionNotFoundMessage(actionId)
-		}
+		// No actions defined
+		return actionNotFoundMessage(actionId as never)
 	}
 	getStatus(): DeviceStatus {
 		let statusCode = StatusCode.GOOD

--- a/packages/timeline-state-resolver/src/integrations/quantel/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/index.ts
@@ -15,13 +15,14 @@ import {
 	Timeline,
 	TSRTimelineContent,
 	QuantelActions,
-	ActionExecutionResult,
 	ActionExecutionResultCode,
+	QuantelActionExecutionPayload,
+	QuantelActionExecutionResult,
 } from 'timeline-state-resolver-types'
 
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
 import { QuantelGateway } from 'tv-automation-quantel-gateway-client'
-import { startTrace, endTrace, t } from '../../lib'
+import { startTrace, endTrace, actionNotFoundMessage } from '../../lib'
 import { QuantelManager } from './connection'
 import {
 	QuantelCommand,
@@ -189,7 +190,10 @@ export class QuantelDevice extends DeviceWithState<QuantelState, DeviceOptionsQu
 			throw new Error('Quantel Gateway not connected')
 		}
 	}
-	async executeAction(actionId: string, _payload?: Record<string, any> | undefined): Promise<ActionExecutionResult> {
+	async executeAction<A extends QuantelActions>(
+		actionId: A,
+		_payload: QuantelActionExecutionPayload<A>
+	): Promise<QuantelActionExecutionResult<A>> {
 		switch (actionId) {
 			case QuantelActions.RestartGateway:
 				try {
@@ -202,7 +206,7 @@ export class QuantelDevice extends DeviceWithState<QuantelState, DeviceOptionsQu
 				this.clearStates()
 				return { result: ActionExecutionResultCode.Ok }
 			default:
-				return { result: ActionExecutionResultCode.Ok, response: t('Action "{{id}}" not found', { id: actionId }) }
+				return actionNotFoundMessage(actionId)
 		}
 	}
 

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -16,8 +16,9 @@ import {
 	ResolvedTimelineObjectInstanceExtended,
 	Mapping,
 	SisyfosActions,
-	ActionExecutionResult,
 	ActionExecutionResultCode,
+	SisyfosActionExecutionPayload,
+	SisyfosActionExecutionResult,
 } from 'timeline-state-resolver-types'
 
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
@@ -207,10 +208,11 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 		return Promise.resolve()
 	}
 
-	async executeAction(
-		actionId: SisyfosActions,
-		_payload?: Record<string, any> | undefined
-	): Promise<ActionExecutionResult> {
+	async executeAction<A extends SisyfosActions>(
+		actionId0: A,
+		_payload: SisyfosActionExecutionPayload<A>
+	): Promise<SisyfosActionExecutionResult<A>> {
+		const actionId = actionId0 as SisyfosActions // type fix for when there is only a single action
 		switch (actionId) {
 			case SisyfosActions.Reinit:
 				return this._makeReadyInner()

--- a/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
@@ -8,9 +8,10 @@ import {
 	SomeMappingSofieChef,
 	TSRTimelineContent,
 	Timeline,
-	ActionExecutionResult,
 	ActionExecutionResultCode,
 	SofieChefActions,
+	SofieChefActionExecutionPayload,
+	SofieChefActionExecutionResult,
 } from 'timeline-state-resolver-types'
 
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
@@ -279,10 +280,10 @@ export class SofieChefDevice extends DeviceWithState<SofieChefState, DeviceOptio
 			windowId: windowId,
 		})
 	}
-	async executeAction(
-		actionId: SofieChefActions,
-		payload?: Record<string, any> | undefined
-	): Promise<ActionExecutionResult> {
+	async executeAction<A extends SofieChefActions>(
+		actionId: A,
+		payload: SofieChefActionExecutionPayload<A>
+	): Promise<SofieChefActionExecutionResult<A>> {
 		switch (actionId) {
 			case SofieChefActions.RestartAllWindows:
 				return this.restartAllWindows()

--- a/packages/timeline-state-resolver/src/lib.ts
+++ b/packages/timeline-state-resolver/src/lib.ts
@@ -7,6 +7,7 @@ import {
 	ITranslatableMessage,
 	ActionExecutionResultCode,
 	TimelineDatastoreReferences,
+	ActionExecutionResult,
 } from 'timeline-state-resolver-types'
 import * as _ from 'underscore'
 
@@ -283,7 +284,9 @@ export function assertNever(_never: never): void {
 	// Do nothing. This is a type guard
 }
 
-export function actionNotFoundMessage(id: string) {
+export function actionNotFoundMessage(id: never): ActionExecutionResult<any> {
+	// Note: (id: never) is an assertNever(actionId)
+
 	return {
 		result: ActionExecutionResultCode.Error,
 		response: t('Action "{{id}}" not found', { id }),

--- a/packages/timeline-state-resolver/src/service/DeviceInstance.ts
+++ b/packages/timeline-state-resolver/src/service/DeviceInstance.ts
@@ -1,7 +1,6 @@
 import EventEmitter = require('eventemitter3')
-import { FinishedTrace, t } from '../lib'
+import { actionNotFoundMessage, FinishedTrace } from '../lib'
 import {
-	ActionExecutionResultCode,
 	type DeviceStatus,
 	type DeviceType,
 	type Mappings,
@@ -135,10 +134,7 @@ export class DeviceInstanceWrapper extends EventEmitter<DeviceInstanceEvents> {
 		const action = this._device.actions[id]
 
 		if (!action) {
-			return {
-				result: ActionExecutionResultCode.Error,
-				response: t('Action "{{id}}" not found', { id }),
-			}
+			return actionNotFoundMessage(id as never)
 		}
 
 		return action(id, payload)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3126,14 +3126,14 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"casparcg-connection@npm:^6.0.6":
-  version: 6.0.6
-  resolution: "casparcg-connection@npm:6.0.6"
+"casparcg-connection@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "casparcg-connection@npm:6.1.1"
   dependencies:
-    eventemitter3: ^4.0.7
+    eventemitter3: ^5.0.1
     tslib: ^2.5.0
-    xml2js: ^0.4.23
-  checksum: f2c02bdfaf29e1c43449a577f1b91fd5ce14ff91bdc6a48dbe5908c1420f5eaf9a3989454f750f93fbe8de399310e76a112e88866bcc3c18398e0e81b43f4dd1
+    xml2js: ^0.6.2
+  checksum: df4e9787386fe560b5bfe743bb38f8188e778d985a72bf0a2ee0f058d038e544cccfbdefcebbacc837c9dbd953be9a435075ac71a0d6a5c2be3488744473fe10
   languageName: node
   linkType: hard
 
@@ -4689,6 +4689,13 @@ asn1@evs-broadcast/node-asn1:
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
+  languageName: node
+  linkType: hard
+
+"eventemitter3@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "eventemitter3@npm:5.0.1"
+  checksum: 543d6c858ab699303c3c32e0f0f47fc64d360bf73c3daf0ac0b5079710e340d6fe9f15487f94e66c629f5f82cd1a8678d692f3dbb6f6fcd1190e1b97fcad36f8
   languageName: node
   linkType: hard
 
@@ -11384,7 +11391,7 @@ asn1@evs-broadcast/node-asn1:
     atem-connection: 2.5.0
     atem-state: 0.13.0
     cacheable-lookup: ^5.0.3
-    casparcg-connection: ^6.0.6
+    casparcg-connection: ^6.1.1
     casparcg-state: ^3.0.2
     debug: ^4.3.4
     deepmerge: ^4.3.1
@@ -12493,6 +12500,16 @@ asn1@evs-broadcast/node-asn1:
     sax: ">=0.6.0"
     xmlbuilder: ~11.0.0
   checksum: ca0cf2dfbf6deeaae878a891c8fbc0db6fd04398087084edf143cdc83d0509ad0fe199b890f62f39c4415cf60268a27a6aed0d343f0658f8779bd7add690fa98
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "xml2js@npm:0.6.2"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~11.0.0
+  checksum: 458a83806193008edff44562c0bdb982801d61ee7867ae58fd35fab781e69e17f40dfeb8fc05391a4648c9c54012066d3955fe5d993ffbe4dc63399023f32ac2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
(This is a PR from SuperFly.tv)


## Background

We have an application, [SuperConductor](https://github.com/SuperFlyTV/SuperConductor), which uses TSR as its backend playout engine.
SuperConductor needs to talk to the devices to retrieve certain data, however currently it has to open a secondary connection to the devices, sine TSR doesn't expose any direct methods that it can use.

With this PR I'd like to propose a way to solve this issue.

### Example of use case

SuperConductor needs the list of media in CasparCG media folder. To retrieve this, it runs `casparcg.cls()`.


## Summary of changes

* Adds `returnData` to the actions schema.
* Modify `schema-types.mjs` script to generate types for both the `payload` and `returnData` along with helper types to use these in the devices.
* Adds `listMedia` action to CasparCG device as an example implementation


## Other information

TODO:

- [x] Draft schema changes
- [x] Example implementation (`CasaparCG.listMedia`)
- [x] Open PR and invite discussion
- [x] Schema approved after discussion
- [x] Test and verify example implementation in QuickTSR
- [ ] Merge PR
- [ ] Open secondary PR with more actions needed in SuperConductor

