### PR TITLE
feat: VizMSE action to send clear-commands (configured on the device …

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/vizMSE.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vizMSE.ts
@@ -5,4 +5,5 @@
  */
 export enum VizMSEActions {
 	PurgeRundown = 'purgeRundown',
+	ClearAllEngines = 'clearAllEngines',
 }

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/$schemas/actions.json
@@ -7,6 +7,13 @@
 			"description": "Purges all elements from the viz-rundown",
 			"destructive": true,
 			"timeout": 10000
+		},
+		{
+			"id": "clearAllEngines",
+			"name": "Clear Engines",
+			"description": "Clears all Engines in the Profile by sending the configured list of clear-commands",
+			"destructive": true,
+			"timeout": 10000
 		}
 	]
 }

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
@@ -214,11 +214,23 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 	public async purgeRundown(clearAll: boolean): Promise<void> {
 		await this._vizmseManager?.purgeRundown(clearAll)
 	}
+	public async clearEngines(): Promise<void> {
+		await this._vizmseManager?.clearEngines({
+			type: VizMSECommandType.CLEAR_ALL_ENGINES,
+			time: this.getCurrentTime(),
+			timelineObjId: 'clearAllEnginesAction',
+			channels: 'all',
+			commands: this._initOptions?.clearAllCommands || [],
+		})
+	}
 
 	async executeAction(actionId: string, _payload?: Record<string, any> | undefined): Promise<ActionExecutionResult> {
 		switch (actionId) {
 			case VizMSEActions.PurgeRundown:
 				await this.purgeRundown(true)
+				return { result: ActionExecutionResultCode.Ok }
+			case VizMSEActions.ClearAllEngines:
+				await this.clearEngines()
 				return { result: ActionExecutionResultCode.Ok }
 			default:
 				return { result: ActionExecutionResultCode.Ok, response: t('Action "{{id}}" not found', { actionId }) }


### PR DESCRIPTION
VizMSE action to send clear-commands (configured on the device ettings) to all Engines in the Profile

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
You can only achieve `clearEngines` on `makeReady`.


* **What is the new behavior (if this is a feature change)?**
Exposes a TSR action for `clearAllEngines` which clears all Engines known in the Profile.


* **Other information**:
