### PR TITLE
fix: reset atem upon connection

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/__tests__/testlib.ts
+++ b/packages/timeline-state-resolver/src/integrations/__tests__/testlib.ts
@@ -2,7 +2,7 @@ import { DeviceContextAPI } from '../../service/device'
 
 /** A default context for devices used in unit tests */
 
-export function getDeviceContext(): DeviceContextAPI {
+export function getDeviceContext(): DeviceContextAPI<any> {
 	return {
 		logger: {
 			error: jest.fn(),

--- a/packages/timeline-state-resolver/src/integrations/__tests__/testlib.ts
+++ b/packages/timeline-state-resolver/src/integrations/__tests__/testlib.ts
@@ -17,6 +17,7 @@ export function getDeviceContext(): DeviceContextAPI {
 		updateMediaObject: jest.fn(),
 		clearMediaObjects: jest.fn(),
 		timeTrace: jest.fn(),
-		resetState: jest.fn(),
+		resetState: jest.fn(async () => Promise.resolve()),
+		resetToState: jest.fn(async () => Promise.resolve()),
 	}
 }

--- a/packages/timeline-state-resolver/src/integrations/atem/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/index.ts
@@ -65,10 +65,16 @@ export class AtemDevice extends Device<AtemOptions, AtemDeviceState, AtemCommand
 			this._connected = true
 
 			this._connectionChanged()
-			this.context.resetResolver()
 
 			if (this._atem.state) {
+				// Do a state diff to get to the desired state
 				this._protocolVersion = this._atem.state.info.apiVersion
+				this.context
+					.resetToState(this._atem.state)
+					.catch((e) => this.context.logger.error('Error resetting atem state', new Error(e)))
+			} else {
+				// Do a state diff to at least send all the commands we know about
+				this.context.resetState().catch((e) => this.context.logger.error('Error resetting atem state', new Error(e)))
 			}
 		})
 

--- a/packages/timeline-state-resolver/src/service/DeviceInstance.ts
+++ b/packages/timeline-state-resolver/src/service/DeviceInstance.ts
@@ -194,7 +194,7 @@ export class DeviceInstanceWrapper extends EventEmitter<DeviceInstanceEvents> {
 		this._logDebugStates = value
 	}
 
-	private _getDeviceContextAPI(): DeviceContextAPI {
+	private _getDeviceContextAPI(): DeviceContextAPI<any> {
 		return {
 			logger: {
 				error: (context: string, err: Error) => {

--- a/packages/timeline-state-resolver/src/service/DeviceInstance.ts
+++ b/packages/timeline-state-resolver/src/service/DeviceInstance.ts
@@ -242,6 +242,13 @@ export class DeviceInstanceWrapper extends EventEmitter<DeviceInstanceEvents> {
 			},
 
 			resetState: async () => {
+				await this._stateHandler.setCurrentState(undefined)
+				await this._stateHandler.clearFutureStates()
+				this.emit('resetResolver')
+			},
+
+			resetToState: async (state: any) => {
+				await this._stateHandler.setCurrentState(state)
 				await this._stateHandler.clearFutureStates()
 				this.emit('resetResolver')
 			},

--- a/packages/timeline-state-resolver/src/service/device.ts
+++ b/packages/timeline-state-resolver/src/service/device.ts
@@ -136,7 +136,11 @@ export interface DeviceContextAPI {
 
 	/** Notify that the connection status has changed. */
 	connectionChanged: (status: Omit<DeviceStatus, 'active'>) => void
-	/** Notify the conductor that it should reset the resolver, in order to trigger it again. */
+	/**
+	 * Notify the conductor that it should reset the resolver, in order to trigger it again.
+	 * Note: this will not change anything about the current state and should technically not lead
+	 * to any new commands being sent
+	 */
 	resetResolver: () => void
 
 	/** Something went wrong when executing a command  */
@@ -148,6 +152,9 @@ export interface DeviceContextAPI {
 
 	timeTrace: (trace: FinishedTrace) => void
 
-	/** Reset the state of the State */
+	/** Reset the tracked device state to undefined and notify the conductor to reset the resolver */
 	resetState: () => Promise<void>
+
+	/** Reset the tracked device state to "state" and notify the conductor to reset the resolver */
+	resetToState: (state: any) => Promise<void> // todo - types?
 }

--- a/packages/timeline-state-resolver/src/service/device.ts
+++ b/packages/timeline-state-resolver/src/service/device.ts
@@ -24,7 +24,7 @@ export type CommandWithContext = {
 export abstract class Device<DeviceOptions, DeviceState, Command extends CommandWithContext>
 	implements BaseDeviceAPI<DeviceState, Command>
 {
-	constructor(protected context: DeviceContextAPI) {
+	constructor(protected context: DeviceContextAPI<DeviceState>) {
 		// Nothing
 	}
 	/**
@@ -119,7 +119,7 @@ export interface DeviceEvents {
 }
 
 /** Various methods that the Devices can call */
-export interface DeviceContextAPI {
+export interface DeviceContextAPI<DeviceState> {
 	logger: {
 		/** Emit a "error" message */
 		error: (context: string, err: Error) => void
@@ -156,5 +156,5 @@ export interface DeviceContextAPI {
 	resetState: () => Promise<void>
 
 	/** Reset the tracked device state to "state" and notify the conductor to reset the resolver */
-	resetToState: (state: any) => Promise<void> // todo - types?
+	resetToState: (state: DeviceState) => Promise<void>
 }

--- a/packages/timeline-state-resolver/src/service/devices.ts
+++ b/packages/timeline-state-resolver/src/service/devices.ts
@@ -9,7 +9,7 @@ import { AtemDevice } from '../integrations/atem'
 import { TcpSendDevice } from '../integrations/tcpSend'
 
 export interface DeviceEntry {
-	deviceClass: new (context: DeviceContextAPI) => Device<any, any, any>
+	deviceClass: new (context: DeviceContextAPI<any>) => Device<any, any, any>
 	canConnect: boolean
 	deviceName: (deviceId: string, options: any) => string
 	executionMode: (options: any) => 'salvo' | 'sequential'


### PR DESCRIPTION
This is a bug fix.

**Expected behaviour**

The atem integration will initiate correctly and enforce its state.

**Observed behaviour**

The atem integration does a state diff before it has connected to the actual device. This returns no commands. The State Handler than transitions to this state and expects it to be current.

Once the device is connected, a `resetResolver` is called. This does not reset the state itself causing it to diff against an incorrect current state and will again return no commands

**Proposed fix**

Add a method to update the current state in the State Handler on the context. In addition, chane the `resetState` context method to change the current state to `undefined`