### PR TITLE
fix: suppress quantel disconnect shortly

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/quantel.ts
+++ b/packages/timeline-state-resolver-types/src/generated/quantel.ts
@@ -31,6 +31,10 @@ export interface QuantelOptions {
 	 * If set: If a clip turns out to be on the wrong server, an attempt to copy the clip will be done
 	 */
 	allowCloneClips?: boolean
+	/**
+	 * If the ISA goes down the gateway will temporarily emit a disconnection warning, this is a false flag when a backup ISA is available. This option will suppress the disconnection warning for a number of ms to give the system time to switch without warnings.
+	 */
+	suppressDisconnectTime?: number
 }
 
 export interface MappingQuantelPort {

--- a/packages/timeline-state-resolver/src/integrations/quantel/$schemas/options.json
+++ b/packages/timeline-state-resolver/src/integrations/quantel/$schemas/options.json
@@ -34,6 +34,11 @@
 			"ui:title": "Allow cloning of clips if on wrong server/pool",
 			"description": "If set: If a clip turns out to be on the wrong server, an attempt to copy the clip will be done",
 			"default": false
+		},
+		"suppressDisconnectTime": {
+			"type": "integer",
+			"ui:title": "Time to suppress disconnection warnings for",
+			"description": "If the ISA goes down the gateway will temporarily emit a disconnection warning, this is a false flag when a backup ISA is available. This option will suppress the disconnection warning for a number of ms to give the system time to switch without warnings."
 		}
 	},
 	"required": ["gatewayUrl", "ISAUrlMaster", "serverId"],


### PR DESCRIPTION
## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: fix / improvement


## Current Behavior
When the connection to the ISA is lost a connection error is immediately emitted.


## New Behavior
When the connection to the ISA is lost the connection error will be suppressed momentarily. This allows it to fail over to a backup isa quietly.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
