### PR TITLE
feat: atem color generator support SOFIE-2968

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/atem.ts
+++ b/packages/timeline-state-resolver-types/src/generated/atem.ts
@@ -67,6 +67,11 @@ export interface MappingAtemAudioRouting {
 	mappingType: MappingAtemType.AudioRouting
 }
 
+export interface MappingAtemColorGenerator {
+	index: number
+	mappingType: MappingAtemType.ColorGenerator
+}
+
 export enum MappingAtemType {
 	MixEffect = 'mixEffect',
 	DownStreamKeyer = 'downStreamKeyer',
@@ -77,9 +82,10 @@ export enum MappingAtemType {
 	AudioChannel = 'audioChannel',
 	MacroPlayer = 'macroPlayer',
 	AudioRouting = 'audioRouting',
+	ColorGenerator = 'colorGenerator',
 }
 
-export type SomeMappingAtem = MappingAtemMixEffect | MappingAtemDownStreamKeyer | MappingAtemSuperSourceBox | MappingAtemAuxilliary | MappingAtemMediaPlayer | MappingAtemSuperSourceProperties | MappingAtemAudioChannel | MappingAtemMacroPlayer | MappingAtemAudioRouting
+export type SomeMappingAtem = MappingAtemMixEffect | MappingAtemDownStreamKeyer | MappingAtemSuperSourceBox | MappingAtemAuxilliary | MappingAtemMediaPlayer | MappingAtemSuperSourceProperties | MappingAtemAudioChannel | MappingAtemMacroPlayer | MappingAtemAudioRouting | MappingAtemColorGenerator
 
 export enum AtemActions {
 	Resync = 'resync'

--- a/packages/timeline-state-resolver-types/src/integrations/atem.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/atem.ts
@@ -421,8 +421,11 @@ export interface TimelineContentAtemColorGenerator extends TimelineContentAtemBa
 	type: TimelineContentTypeAtem.COLORGENERATOR
 
 	colorGenerator: {
+		/** 0-3599 */
 		hue: number
+		/** 0-1000 */
 		saturation: number
+		/** 0-1000 */
 		luma: number
 	}
 }

--- a/packages/timeline-state-resolver-types/src/integrations/atem.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/atem.ts
@@ -10,6 +10,7 @@ export enum TimelineContentTypeAtem { //  Atem-state
 	AUDIOCHANNEL = 'audioChan',
 	MACROPLAYER = 'macroPlayer',
 	AUDIOROUTING = 'audioRouting',
+	COLORGENERATOR = 'colorGenerator',
 }
 
 export enum AtemTransitionStyle { // Note: copied from atem-state
@@ -112,6 +113,7 @@ export type TimelineContentAtemAny =
 	| TimelineContentAtemAudioChannel
 	| TimelineContentAtemMediaPlayer
 	| TimelineContentAtemAudioRouting
+	| TimelineContentAtemColorGenerator
 
 export interface TimelineContentAtemBase {
 	deviceType: DeviceType.ATEM
@@ -412,5 +414,15 @@ export interface TimelineContentAtemAudioRouting extends TimelineContentAtemBase
 	type: TimelineContentTypeAtem.AUDIOROUTING
 	audioRouting: {
 		sourceId: number
+	}
+}
+
+export interface TimelineContentAtemColorGenerator extends TimelineContentAtemBase {
+	type: TimelineContentTypeAtem.COLORGENERATOR
+
+	colorGenerator: {
+		hue: number
+		saturation: number
+		luma: number
 	}
 }

--- a/packages/timeline-state-resolver/src/integrations/atem/$schemas/mappings.json
+++ b/packages/timeline-state-resolver/src/integrations/atem/$schemas/mappings.json
@@ -128,6 +128,21 @@
 			},
 			"required": ["index"],
 			"additionalProperties": false
+		},
+		"colorGenerator": {
+			"type": "object",
+			"properties": {
+				"index": {
+					"type": "integer",
+					"ui:title": "Index",
+					"ui:summaryTitle": "Color Generator",
+					"default": 0,
+					"min": 0,
+					"ui:zeroBased": true
+				}
+			},
+			"required": ["index"],
+			"additionalProperties": false
 		}
 	}
 }

--- a/packages/timeline-state-resolver/src/integrations/atem/__tests__/__snapshots__/diffStates.spec.ts.snap
+++ b/packages/timeline-state-resolver/src/integrations/atem/__tests__/__snapshots__/diffStates.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`Diff States Simple diff against empty state 1`] = `
       "monitorOutput": undefined,
     },
   },
-  "colorGenerators": undefined,
+  "colorGenerators": [],
   "macros": {
     "player": {
       "player": true,

--- a/packages/timeline-state-resolver/src/integrations/atem/__tests__/stateBuilder.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/__tests__/stateBuilder.spec.ts
@@ -6,6 +6,7 @@ import {
 	MappingAtemAudioChannel,
 	MappingAtemAudioRouting,
 	MappingAtemAuxilliary,
+	MappingAtemColorGenerator,
 	MappingAtemDownStreamKeyer,
 	MappingAtemMacroPlayer,
 	MappingAtemMediaPlayer,
@@ -20,6 +21,7 @@ import {
 	TimelineContentAtemAUX,
 	TimelineContentAtemAudioChannel,
 	TimelineContentAtemAudioRouting,
+	TimelineContentAtemColorGenerator,
 	TimelineContentAtemDSK,
 	TimelineContentAtemMacroPlayer,
 	TimelineContentAtemMediaPlayer,
@@ -636,6 +638,54 @@ describe('AtemStateBuilder', () => {
 				isWaiting: false,
 				loop: true,
 				macroIndex: 4,
+			}
+
+			const deviceState1 = AtemStateBuilder.fromTimeline(mockState1, myLayerMapping)
+			expect(deviceState1).toEqual(expectedState)
+		})
+	})
+
+	describe('Color Generator', () => {
+		const myLayerMapping0: Mapping<MappingAtemColorGenerator> = {
+			device: DeviceType.ATEM,
+			deviceId: 'myAtem',
+			options: {
+				mappingType: MappingAtemType.ColorGenerator,
+				index: 0,
+			},
+		}
+		const myLayerMapping: Mappings = {
+			myLayer0: myLayerMapping0,
+		}
+
+		test('Basic', async () => {
+			const mockState1: Timeline.StateInTime<TimelineContentAtemColorGenerator> = {
+				myLayer0: makeTimelineObjectResolved<TimelineContentAtemColorGenerator>({
+					id: 'obj0',
+					enable: {
+						start: -1000, // 1 seconds ago
+						duration: 2000,
+					},
+					layer: 'myLayer0',
+					content: {
+						deviceType: DeviceType.ATEM,
+						type: TimelineContentTypeAtem.COLORGENERATOR,
+						colorGenerator: {
+							hue: 123,
+							luma: 456,
+							saturation: 789,
+						},
+					},
+				}),
+			}
+
+			const expectedState = AtemConnection.AtemStateUtil.Create()
+			expectedState.colorGenerators = {
+				[0]: {
+					hue: 123,
+					luma: 456,
+					saturation: 789,
+				},
 			}
 
 			const deviceState1 = AtemStateBuilder.fromTimeline(mockState1, myLayerMapping)

--- a/packages/timeline-state-resolver/src/integrations/atem/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/index.ts
@@ -8,6 +8,7 @@ import {
 	ActionExecutionResult,
 	ActionExecutionResultCode,
 	AtemActions,
+	SomeMappingAtem,
 } from 'timeline-state-resolver-types'
 import { AtemState, State as DeviceState } from 'atem-state'
 import {
@@ -160,7 +161,7 @@ export class AtemDevice extends Device<AtemOptions, AtemDeviceState, AtemCommand
 		// Make sure there is something to diff against
 		oldAtemState = oldAtemState ?? this._atem.state ?? AtemStateUtil.Create()
 
-		const diffOptions = createDiffOptions(mappings)
+		const diffOptions = createDiffOptions(mappings as Mappings<SomeMappingAtem>)
 		const commands = AtemState.diffStates(this._protocolVersion, oldAtemState, newAtemState, diffOptions)
 
 		if (commands.length > 0) {

--- a/packages/timeline-state-resolver/src/integrations/atem/stateBuilder.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/stateBuilder.ts
@@ -27,9 +27,11 @@ import {
 	MappingAtemDownStreamKeyer,
 	MappingAtemAudioRouting,
 	TimelineContentAtemAudioRouting,
+	MappingAtemColorGenerator,
+	TimelineContentAtemColorGenerator,
 } from 'timeline-state-resolver-types'
 import _ = require('underscore')
-import { State as DeviceState, Defaults as StateDefault } from 'atem-state'
+import { Defaults, State as DeviceState, Defaults as StateDefault } from 'atem-state'
 import { assertNever, cloneDeep, deepMerge, literal } from '../../lib'
 import { PartialDeep } from 'type-fest'
 
@@ -96,6 +98,11 @@ export class AtemStateBuilder {
 					case MappingAtemType.MacroPlayer:
 						if (content.type === TimelineContentTypeAtem.MACROPLAYER) {
 							builder._applyMacroPlayer(mapping.options, content)
+						}
+						break
+					case MappingAtemType.ColorGenerator:
+						if (content.type === TimelineContentTypeAtem.COLORGENERATOR) {
+							builder._applyColorGenerator(mapping.options, content)
 						}
 						break
 					default:
@@ -293,5 +300,14 @@ export class AtemStateBuilder {
 			this.#deviceState.macro.macroPlayer,
 			content.macroPlayer
 		)
+	}
+
+	private _applyColorGenerator(mapping: MappingAtemColorGenerator, content: TimelineContentAtemColorGenerator): void {
+		if (!this.#deviceState.colorGenerators) this.#deviceState.colorGenerators = {}
+		this.#deviceState.colorGenerators[mapping.index] = {
+			...Defaults.Color.ColorGenerator,
+			...this.#deviceState.colorGenerators[mapping.index],
+			...content.colorGenerator,
+		}
 	}
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Feature


## New Behavior
It is now possible to control the color generators on a Blackmagic ATEM switcher.

This is only done for color generators where there is a mapping in Sofie. 


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
