### PR TITLE
Feat/sisyfos bbc enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:main": "cd packages/timeline-state-resolver && yarn build",
     "lint": "lerna exec yarn lint -- --",
     "test": "lerna exec yarn test",
+    "test:changed": "lerna run --since origin/master --include-dependents test",
     "unit": "lerna exec yarn unit",
     "unitci": "lerna exec yarn unitci",
     "watch": "lerna run --parallel build:main -- --watch --preserveWatchOutput",

--- a/packages/quick-tsr/src/index.ts
+++ b/packages/quick-tsr/src/index.ts
@@ -144,6 +144,12 @@ function reloadInput(changed?: { path: string; stats: fs.Stats }) {
 				currentInput.mappings = clone(newInput.mappings)
 				currentInput.timeline = clone(newInput.timeline)
 
+				// Check that layers are correct.
+				newInput.timeline.forEach((obj) => {
+					if (!newInput.mappings[obj.layer])
+						console.error(`Object ${obj.id} refers to a layer/mapping that does not exist: "${obj.layer}"`)
+				})
+
 				tsr.setTimelineAndMappings(newInput.timeline, newInput.mappings)
 			}
 			if (!_.isEqual(newInput.datastore, currentInput.datastore)) {

--- a/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
+++ b/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
@@ -34,17 +34,17 @@ export enum MappingSisyfosType {
 
 export type SomeMappingSisyfos = MappingSisyfosChannel | MappingSisyfosChannelByLabel | MappingSisyfosChannels
 
-export interface ReinitChannelPayload {
+export interface ReSyncChannelPayload {
 	[k: string]: unknown
 }
 
 export enum SisyfosActions {
 	Reinit = 'reinit',
-	ReinitChannel = 'reinitChannel'
+	ReSyncChannel = 'reSyncChannel'
 }
 export interface SisyfosActionExecutionResults {
 	reinit: () => void,
-	reinitChannel: (payload: ReinitChannelPayload) => void
+	reSyncChannel: (payload: ReSyncChannelPayload) => void
 }
 export type SisyfosActionExecutionPayload<A extends keyof SisyfosActionExecutionResults> = Parameters<
 	SisyfosActionExecutionResults[A]

--- a/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
+++ b/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
@@ -38,13 +38,19 @@ export interface ReSyncChannelPayload {
 	[k: string]: unknown
 }
 
+export interface SetSisyfosChannelStatePayload {
+	[k: string]: unknown
+}
+
 export enum SisyfosActions {
 	Reinit = 'reinit',
-	ReSyncChannel = 'reSyncChannel'
+	ReSyncChannel = 'reSyncChannel',
+	SetSisyfosChannelState = 'setSisyfosChannelState'
 }
 export interface SisyfosActionExecutionResults {
 	reinit: () => void,
-	reSyncChannel: (payload: ReSyncChannelPayload) => void
+	reSyncChannel: (payload: ReSyncChannelPayload) => void,
+	setSisyfosChannelState: (payload: SetSisyfosChannelStatePayload) => void
 }
 export type SisyfosActionExecutionPayload<A extends keyof SisyfosActionExecutionResults> = Parameters<
 	SisyfosActionExecutionResults[A]

--- a/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
+++ b/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
@@ -35,11 +35,11 @@ export enum MappingSisyfosType {
 export type SomeMappingSisyfos = MappingSisyfosChannel | MappingSisyfosChannelByLabel | MappingSisyfosChannels
 
 export interface ReSyncChannelPayload {
-	[k: string]: unknown
+	channel: number
 }
 
 export interface SetSisyfosChannelStatePayload {
-	[k: string]: unknown
+	channel: number
 }
 
 export enum SisyfosActions {

--- a/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
+++ b/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
@@ -34,11 +34,17 @@ export enum MappingSisyfosType {
 
 export type SomeMappingSisyfos = MappingSisyfosChannel | MappingSisyfosChannelByLabel | MappingSisyfosChannels
 
+export interface ReinitChannelPayload {
+	[k: string]: unknown
+}
+
 export enum SisyfosActions {
-	Reinit = 'reinit'
+	Reinit = 'reinit',
+	ReinitChannel = 'reinitChannel'
 }
 export interface SisyfosActionExecutionResults {
-	reinit: () => void
+	reinit: () => void,
+	reinitChannel: (payload: ReinitChannelPayload) => void
 }
 export type SisyfosActionExecutionPayload<A extends keyof SisyfosActionExecutionResults> = Parameters<
 	SisyfosActionExecutionResults[A]

--- a/packages/timeline-state-resolver-types/src/integrations/sisyfos.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/sisyfos.ts
@@ -22,6 +22,9 @@ export interface SisyfosChannelOptions {
 	label?: string
 	visible?: boolean
 	fadeTime?: number
+	muteOn?: boolean
+	inputGain?: number
+	inputSelector?: number
 }
 
 export interface TimelineContentSisyfosTriggerValue extends TimelineContentSisyfos {

--- a/packages/timeline-state-resolver-types/src/integrations/sisyfos.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/sisyfos.ts
@@ -1,5 +1,10 @@
 import { DeviceType } from '..'
 
+/*
+ * TRIGGERVALUE is used to SET_CHANNEL in Sisyfos
+ * When value is changed to a new value (e.g. Date.now()) Sisyfos will set the channel to
+ * the Current TSR State using setSisyfosChannel()
+ */
 export enum TimelineContentTypeSisyfos {
 	CHANNEL = 'channel',
 	CHANNELS = 'channels',

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/$schemas/actions.json
@@ -11,7 +11,14 @@
 			"id": "reSyncChannel",
 			"name": "ReSyncChannel",
 			"payload": {
-				"channel": 1
+				"type": "object",
+				"properties": {
+					"channel": {
+						"type": "number"
+					}
+				},
+				"additionalProperties": false,
+				"required": ["channel"]
 			},
 			"destructive": false,
 			"timeout": 5000
@@ -20,7 +27,14 @@
 			"id": "setSisyfosChannelState",
 			"name": "SetSisyfosChannelState",
 			"payload": {
-				"channel": 1
+				"type": "object",
+				"properties": {
+					"channel": {
+						"type": "number"
+					}
+				},
+				"additionalProperties": false,
+				"required": ["channel"]
 			},
 			"destructive": false,
 			"timeout": 5000

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/$schemas/actions.json
@@ -15,6 +15,15 @@
 			},
 			"destructive": false,
 			"timeout": 5000
+		},
+		{
+			"id": "setSisyfosChannelState",
+			"name": "SetSisyfosChannelState",
+			"payload": {
+				"channel": 1
+			},
+			"destructive": false,
+			"timeout": 5000
 		}
 	]
 }

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/$schemas/actions.json
@@ -8,8 +8,8 @@
 			"timeout": 5000
 		},
 		{
-			"id": "reinitChannel",
-			"name": "ReinitializeChannel",
+			"id": "reSyncChannel",
+			"name": "ReSyncChannel",
 			"payload": {
 				"channel": 1
 			},

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/$schemas/actions.json
@@ -6,6 +6,15 @@
 			"name": "Reinitialize",
 			"destructive": false,
 			"timeout": 5000
+		},
+		{
+			"id": "reinitChannel",
+			"name": "ReinitializeChannel",
+			"payload": {
+				"channel": 1
+			},
+			"destructive": false,
+			"timeout": 5000
 		}
 	]
 }

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -132,9 +132,19 @@ export class SisyfosApi extends EventEmitter {
 					},
 				],
 			})
+		} else if (command.type === SisyfosCommandType.SET_MUTE) {
+			this._oscClient.send({
+				address: `/ch/${command.channel + 1}/mute`,
+				args: [
+					{
+						type: 'i',
+						value: command.value === true ? 1 : 0,
+					},
+				],
+			})
 		} else if (command.type === SisyfosCommandType.SET_INPUT_GAIN) {
 			this._oscClient.send({
-				address: `/ch/${command.channel + 1}/faderlevel`,
+				address: `/ch/${command.channel + 1}/inputgain`,
 				args: [
 					{
 						type: 'f',
@@ -414,6 +424,7 @@ export enum SisyfosCommandType {
 	SET_FADER = 'setFader',
 	SET_INPUT_GAIN = 'setInputGain',
 	SET_INPUT_SELECTOR = 'setInputSelector',
+	SET_MUTE = 'setMute',
 	CLEAR_PST_ROW = 'clearPstRow',
 	LABEL = 'label',
 	TAKE = 'take',
@@ -443,6 +454,7 @@ export interface ChannelCommand extends BaseCommand {
 		| SisyfosCommandType.RESYNC_CHANNEL
 		| SisyfosCommandType.SET_INPUT_SELECTOR
 		| SisyfosCommandType.SET_INPUT_GAIN
+		| SisyfosCommandType.SET_MUTE
 	channel: number
 }
 
@@ -451,7 +463,7 @@ export interface GlobalCommand extends BaseCommand {
 }
 
 export interface BoolCommand extends ChannelCommand {
-	type: SisyfosCommandType.VISIBLE
+	type: SisyfosCommandType.VISIBLE | SisyfosCommandType.SET_MUTE
 	value: boolean
 }
 export interface ValueCommand extends ChannelCommand {

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -220,6 +220,26 @@ export class SisyfosApi extends EventEmitter {
 		this._oscClient.send({ address: `/ch/${channel}/state`, args: [] })
 	}
 
+	setSisyfosChannel(channel: number, state: SisyfosState) {
+		const channelState: SisyfosChannel = state.channels[channel]
+		const apiState: SisyfosAPIChannel = {
+			faderLevel: channelState.faderLevel,
+			pgmOn: channelState.pgmOn,
+			pstOn: channelState.pstOn,
+			label: channelState.label,
+			visible: channelState.visible,
+			fadeTime: channelState.fadeTime,
+			muteOn: channelState.muteOn,
+			inputGain: channelState.inputGain,
+			inputSelector: channelState.inputSelector,
+		}
+
+		if (!this._oscClient) {
+			throw new Error(`Can't set channel, OSC client not initialised`)
+		}
+		this._oscClient.send({ address: `setChannel/${channel}`, args: JSON.stringify(apiState) })
+	}
+
 	getChannelByLabel(label: string): number | undefined {
 		return this._labelToChannel.get(label)
 	}

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -132,6 +132,26 @@ export class SisyfosApi extends EventEmitter {
 					},
 				],
 			})
+		} else if (command.type === SisyfosCommandType.SET_INPUT_GAIN) {
+			this._oscClient.send({
+				address: `/ch/${command.channel + 1}/faderlevel`,
+				args: [
+					{
+						type: 'f',
+						value: command.value,
+					},
+				],
+			})
+		} else if (command.type === SisyfosCommandType.SET_INPUT_SELECTOR) {
+			this._oscClient.send({
+				address: `/ch/${command.channel + 1}/inputselector`,
+				args: [
+					{
+						type: 'i',
+						value: command.value,
+					},
+				],
+			})
 		} else if (command.type === SisyfosCommandType.SET_CHANNEL) {
 			if (command.values.label) {
 				this._oscClient.send({
@@ -392,6 +412,8 @@ export enum SisyfosCommandType {
 	TOGGLE_PGM = 'togglePgm',
 	TOGGLE_PST = 'togglePst',
 	SET_FADER = 'setFader',
+	SET_INPUT_GAIN = 'setInputGain',
+	SET_INPUT_SELECTOR = 'setInputSelector',
 	CLEAR_PST_ROW = 'clearPstRow',
 	LABEL = 'label',
 	TAKE = 'take',
@@ -419,6 +441,8 @@ export interface ChannelCommand extends BaseCommand {
 		| SisyfosCommandType.LABEL
 		| SisyfosCommandType.VISIBLE
 		| SisyfosCommandType.RESYNC_CHANNEL
+		| SisyfosCommandType.SET_INPUT_SELECTOR
+		| SisyfosCommandType.SET_INPUT_GAIN
 	channel: number
 }
 
@@ -431,7 +455,12 @@ export interface BoolCommand extends ChannelCommand {
 	value: boolean
 }
 export interface ValueCommand extends ChannelCommand {
-	type: SisyfosCommandType.TOGGLE_PST | SisyfosCommandType.VISIBLE | SisyfosCommandType.RESYNC_CHANNEL
+	type:
+		| SisyfosCommandType.TOGGLE_PST
+		| SisyfosCommandType.VISIBLE
+		| SisyfosCommandType.RESYNC_CHANNEL
+		| SisyfosCommandType.SET_INPUT_SELECTOR
+		| SisyfosCommandType.SET_INPUT_GAIN
 	value: number
 }
 

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -394,7 +394,7 @@ export class SisyfosApi extends EventEmitter {
 				pstOn: ch.pstOn === true ? 1 : 0,
 				label: ch.label || '',
 				visible: ch.showChannel ? true : false,
-				fadeTime: ch.fadeTime || 0,
+				fadeTime: ch.fadeTime || undefined,
 				muteOn: ch.muteOn || false,
 				inputGain: ch.inputGain || 0.75,
 				inputSelector: ch.inputSelector || 1,
@@ -499,7 +499,7 @@ export interface SisyfosAPIChannel {
 	pstOn: number
 	label: string
 	visible: boolean
-	fadeTime: number
+	fadeTime?: number
 	muteOn: boolean
 	inputGain: number
 	inputSelector: number

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -213,7 +213,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 	}
 	async executeAction<A extends SisyfosActions>(
 		actionId0: A,
-		_payload: SisyfosActionExecutionPayload<A>
+		payload: SisyfosActionExecutionPayload<A>
 	): Promise<SisyfosActionExecutionResult<A>> {
 		const actionId = actionId0 as SisyfosActions // type fix for when there is only a single action
 		switch (actionId) {
@@ -226,12 +226,12 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 						result: ActionExecutionResultCode.Error,
 					}))
 			case SisyfosActions.ReSyncChannel:
-				if (typeof _payload?.channel !== 'number') {
+				if (typeof payload?.channel !== 'number') {
 					return {
 						result: ActionExecutionResultCode.Error,
 					}
 				}
-				return this._resyncOneChannel(_payload.channel)
+				return this._resyncOneChannel(payload.channel)
 					.then(() => ({
 						result: ActionExecutionResultCode.Ok,
 					}))
@@ -239,12 +239,12 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 						result: ActionExecutionResultCode.Error,
 					}))
 			case SisyfosActions.SetSisyfosChannelState:
-				if (typeof _payload?.channel !== 'number') {
+				if (typeof payload?.channel !== 'number') {
 					return {
 						result: ActionExecutionResultCode.Error,
 					}
 				}
-				this._sisyfos.setSisyfosChannel(_payload.channel, this.getDeviceState())
+				this._sisyfos.setSisyfosChannel(payload.channel, this.getDeviceState())
 				return {
 					result: ActionExecutionResultCode.Ok,
 				}

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -215,7 +215,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 		actionId0: A,
 		payload: SisyfosActionExecutionPayload<A>
 	): Promise<SisyfosActionExecutionResult<A>> {
-		const actionId = actionId0 as SisyfosActions // type fix for when there is only a single action
+		const actionId = actionId0
 		switch (actionId) {
 			case SisyfosActions.Reinit:
 				return this._makeReadyInner()
@@ -304,7 +304,6 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 			pstOn: 0,
 			label: '',
 			visible: true,
-			fadeTime: 0.2,
 			muteOn: false,
 			inputGain: 0.75,
 			inputSelector: 1,

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -229,7 +229,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 					.catch(() => ({
 						result: ActionExecutionResultCode.Error,
 					}))
-			case SisyfosActions.ReinitChannel:
+			case SisyfosActions.ReSyncChannel:
 				if (typeof _payload?.channel !== 'number') {
 					return {
 						result: ActionExecutionResultCode.Error,

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -466,6 +466,9 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 				if (newChannel.label !== undefined && newChannel.label !== '') channel.label = newChannel.label
 				if (newChannel.visible !== undefined) channel.visible = newChannel.visible
 				if (newChannel.fadeTime !== undefined) channel.fadeTime = newChannel.fadeTime
+				if (newChannel.muteOn !== undefined) channel.muteOn = newChannel.muteOn
+				if (newChannel.inputGain !== undefined) channel.inputGain = newChannel.inputGain
+				if (newChannel.inputSelector !== undefined) channel.inputSelector = newChannel.inputSelector
 
 				channel.timelineObjIds.push(newChannel.timelineObjId)
 			}

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -606,6 +606,45 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 					timelineObjId: newChannel.timelineObjIds[0] || '',
 				})
 			}
+
+			if (oldChannel && oldChannel.muteOn !== newChannel.muteOn) {
+				debug(`Channel ${index} mute goes from "${oldChannel.muteOn}" to "${newChannel.muteOn}"`)
+				commands.push({
+					context: `Channel ${index} mute goes from "${oldChannel.muteOn}" to "${newChannel.muteOn}"`,
+					content: {
+						type: SisyfosCommandType.SET_MUTE,
+						channel: Number(index),
+						value: newChannel.muteOn,
+					},
+					timelineObjId: newChannel.timelineObjIds[0] || '',
+				})
+			}
+
+			if (oldChannel && oldChannel.inputGain !== newChannel.inputGain) {
+				debug(`Channel ${index} inputGain goes from "${oldChannel.inputGain}" to "${newChannel.inputGain}"`)
+				commands.push({
+					context: `Channel ${index} inputGain goes from "${oldChannel.inputGain}" to "${newChannel.inputGain}"`,
+					content: {
+						type: SisyfosCommandType.SET_INPUT_GAIN,
+						channel: Number(index),
+						value: newChannel.inputGain,
+					},
+					timelineObjId: newChannel.timelineObjIds[0] || '',
+				})
+			}
+
+			if (oldChannel && oldChannel.inputSelector !== newChannel.inputSelector) {
+				debug(`Channel ${index} inputSelector goes from "${oldChannel.inputSelector}" to "${newChannel.inputSelector}"`)
+				commands.push({
+					context: `Channel ${index} inputSelector goes from "${oldChannel.inputSelector}" to "${newChannel.inputSelector}"`,
+					content: {
+						type: SisyfosCommandType.SET_INPUT_SELECTOR,
+						channel: Number(index),
+						value: newChannel.inputSelector,
+					},
+					timelineObjId: newChannel.timelineObjIds[0] || '',
+				})
+			}
 		})
 
 		return commands

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -207,7 +207,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 		return Promise.resolve()
 	}
 
-	private async _ResyncOneChannel(channel: number): Promise<void> {
+	private async _resyncOneChannel(channel: number): Promise<void> {
 		this._resyncing = true
 		// If state is still not reinitialised afer 5 seconds, we may have a problem.
 		setTimeout(() => (this._resyncing = false), 5000)
@@ -235,7 +235,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 						result: ActionExecutionResultCode.Error,
 					}
 				}
-				return this._ResyncOneChannel(_payload.channel)
+				return this._resyncOneChannel(_payload.channel)
 					.then(() => ({
 						result: ActionExecutionResultCode.Ok,
 					}))

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -244,7 +244,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 						result: ActionExecutionResultCode.Error,
 					}
 				}
-				this._sisyfos.setSisyfosChannel(payload.channel, this.getDeviceState())
+				this._sisyfos.setSisyfosChannel(payload.channel, { ...this.getDeviceState().channels[payload.channel] })
 				return {
 					result: ActionExecutionResultCode.Ok,
 				}


### PR DESCRIPTION
## About the Contributor
This PR is posted on behalf of BBC

## Type of Contribution

This is a: 
Feature request
<!-- (pick one) -->
Bug fix / Feature / Code improvement / Documentation improvement / Other (please specify)

## Old Behavior:
Sisyfos and TSR had some limitation in the API, regarding mute, inputGain & inputSelector. 

## New Behavior
TSR and Sisyfos has been enhanced to include support for optional mute, inputgain, inputselector and get sisyfos state of a fader.
Following changes has been made:
* Added:
  * setMutoOn, setInputgain, setInputSelector in:
    * SisyfosChannelOptions in TSR types sisyfos integration
    * API types SisyfosSendChannelAPI and SisyfosReceiveChannelAPI - with new features as optionals.
    * SisyfosCommandType as SET_INPUT_SELECTOR, SET_INPUT_GAIN and SET_MUTE
  * 2 new actions are added: 
    * ReSyncChannel - the ability to resync a channel from Sisyfos without reconnection (as a full resin/reinit does)
    * SetSisyfosChannelState - works like triggerValue but as an action
  * Updated the receiver() to include receiving a single channel from Sifyfos
* Refactor:
  * the SET_CHANNEL command shares setSisyfosChannel() with the SetSisyfosChannelState action.
  
Fixes:
* quickTSR has been update to check if a timeline refers to an unmapped object.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->
use quickTSR to test the new implementations.
All features implemented as optional, so it don't have breaking changes in the current TSR-Sisyfos behavior.

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ x] PR is ready to be reviewed.
- [ x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
