### PR TITLE
fix(vMix): handling XML messages with multi-byte characters

### DIFF
--- a/packages/timeline-state-resolver/src/__mocks__/net.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/net.ts
@@ -67,7 +67,7 @@ export class Socket extends EventEmitter {
 	public mockClose() {
 		this.setClosed()
 	}
-	public mockData(data: Buffer) {
+	public mockData(data: string) {
 		this.emit('data', data)
 	}
 

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixResponseStreamReader.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixResponseStreamReader.spec.ts
@@ -14,7 +14,7 @@ describe('VMixResponseStreamReader', () => {
 		const onMessage = jest.fn()
 		reader.on('response', onMessage)
 
-		reader.processIncomingData(Buffer.from('VERSION OK 27.0.0.49\r\n'))
+		reader.processIncomingData('VERSION OK 27.0.0.49\r\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(1)
 		expect(onMessage).toHaveBeenCalledWith(
@@ -31,8 +31,8 @@ describe('VMixResponseStreamReader', () => {
 		const onMessage = jest.fn()
 		reader.on('response', onMessage)
 
-		reader.processIncomingData(Buffer.from('VERSION OK 27.0.0.49\r\n'))
-		reader.processIncomingData(Buffer.from('FUNCTION OK Take\r\n'))
+		reader.processIncomingData('VERSION OK 27.0.0.49\r\n')
+		reader.processIncomingData('FUNCTION OK Take\r\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(2)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -58,8 +58,8 @@ describe('VMixResponseStreamReader', () => {
 		const onMessage = jest.fn()
 		reader.on('response', onMessage)
 
-		reader.processIncomingData(Buffer.from('VERSION O'))
-		reader.processIncomingData(Buffer.from('K 27.0.0.49\r\n'))
+		reader.processIncomingData('VERSION O')
+		reader.processIncomingData('K 27.0.0.49\r\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(1)
 		expect(onMessage).toHaveBeenCalledWith(
@@ -76,9 +76,9 @@ describe('VMixResponseStreamReader', () => {
 		const onMessage = jest.fn()
 		reader.on('response', onMessage)
 
-		reader.processIncomingData(Buffer.from('VERSION OK 27.0.0.49\r\n'))
-		reader.processIncomingData(Buffer.from('FUNCTION'))
-		reader.processIncomingData(Buffer.from(' ER Error message\r\n'))
+		reader.processIncomingData('VERSION OK 27.0.0.49\r\n')
+		reader.processIncomingData('FUNCTION')
+		reader.processIncomingData(' ER Error message\r\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(2)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -104,11 +104,11 @@ describe('VMixResponseStreamReader', () => {
 		const onMessage = jest.fn()
 		reader.on('response', onMessage)
 
-		reader.processIncomingData(Buffer.from('VERSION OK 27.0.0.49'))
-		reader.processIncomingData(Buffer.from('\r\n'))
-		reader.processIncomingData(Buffer.from('FUNCTION'))
-		reader.processIncomingData(Buffer.from(' ER Error message\r'))
-		reader.processIncomingData(Buffer.from('\n'))
+		reader.processIncomingData('VERSION OK 27.0.0.49')
+		reader.processIncomingData('\r\n')
+		reader.processIncomingData('FUNCTION')
+		reader.processIncomingData(' ER Error message\r')
+		reader.processIncomingData('\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(2)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -134,7 +134,7 @@ describe('VMixResponseStreamReader', () => {
 		const onMessage = jest.fn()
 		reader.on('response', onMessage)
 
-		reader.processIncomingData(Buffer.from('VERSION OK 27.0.0.49\r\nFUNCTION ER Error message\r\n'))
+		reader.processIncomingData('VERSION OK 27.0.0.49\r\nFUNCTION ER Error message\r\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(2)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -160,8 +160,8 @@ describe('VMixResponseStreamReader', () => {
 		const onMessage = jest.fn()
 		reader.on('response', onMessage)
 
-		reader.processIncomingData(Buffer.from('VERSION OK 27.0.0.49\r\nFUNCTION E'))
-		reader.processIncomingData(Buffer.from('R Error message\r\n'))
+		reader.processIncomingData('VERSION OK 27.0.0.49\r\nFUNCTION E')
+		reader.processIncomingData('R Error message\r\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(2)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -187,9 +187,9 @@ describe('VMixResponseStreamReader', () => {
 		const onMessage = jest.fn()
 		reader.on('response', onMessage)
 
-		reader.processIncomingData(Buffer.from('VERSION OK 27.0.0.49\r\nFUNCTION E'))
-		reader.processIncomingData(Buffer.from('R Error message\r\nFUNCTION OK T'))
-		reader.processIncomingData(Buffer.from('ake\r\n'))
+		reader.processIncomingData('VERSION OK 27.0.0.49\r\nFUNCTION E')
+		reader.processIncomingData('R Error message\r\nFUNCTION OK T')
+		reader.processIncomingData('ake\r\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(3)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -225,7 +225,7 @@ describe('VMixResponseStreamReader', () => {
 
 		const xmlString =
 			'<vmix><version>27.0.0.49</version><edition>HD</edition><preset>C:\\preset.vmix</preset><inputs><inputs></vmix>'
-		reader.processIncomingData(Buffer.from(makeXmlMessage(xmlString)))
+		reader.processIncomingData(makeXmlMessage(xmlString))
 
 		expect(onMessage).toHaveBeenCalledTimes(1)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -246,37 +246,7 @@ describe('VMixResponseStreamReader', () => {
 
 		const xmlString =
 			'<vmix><version>27.0.0.49</version><edition>HD</edition><preset>C:\\🚀\\preset3¾.vmix</preset><inputs><inputs></vmix>'
-		reader.processIncomingData(Buffer.from(makeXmlMessage(xmlString)))
-
-		expect(onMessage).toHaveBeenCalledTimes(1)
-		expect(onMessage).toHaveBeenNthCalledWith(
-			1,
-			expect.objectContaining({
-				command: 'XML',
-				response: 'OK',
-				body: xmlString,
-			})
-		)
-	})
-
-	it('processes a fragmented message with data containing multi-byte characters, split mid-character', async () => {
-		const reader = new VMixResponseStreamReader()
-
-		const onMessage = jest.fn()
-		reader.on('response', onMessage)
-
-		const xmlString = '<vmix>🚀🚀</vmix>'
-		const xmlMessage = `XML 23\r\n${xmlString}\r\n`
-		const fullBuffer = Buffer.from(xmlMessage)
-
-		const firstPart = fullBuffer.slice(0, 16)
-		const secondPart = fullBuffer.slice(16)
-
-		// sanity check that we did actually split mid-character
-		expect(firstPart.toString('utf-8') + secondPart.toString('utf-8')).not.toBe(xmlMessage)
-
-		reader.processIncomingData(firstPart)
-		reader.processIncomingData(secondPart)
+		reader.processIncomingData(makeXmlMessage(xmlString))
 
 		expect(onMessage).toHaveBeenCalledTimes(1)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -299,7 +269,7 @@ describe('VMixResponseStreamReader', () => {
 
 		const xmlString =
 			'<vmix>\r\n<version>27.0.0.49</version>\r\n<edition>HD</edition>\r\n<preset>C:\\preset.vmix</preset>\r\n<inputs><inputs>\r\n</vmix>'
-		reader.processIncomingData(Buffer.from(makeXmlMessage(xmlString)))
+		reader.processIncomingData(makeXmlMessage(xmlString))
 
 		expect(onMessage).toHaveBeenCalledTimes(1)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -323,7 +293,7 @@ describe('VMixResponseStreamReader', () => {
 		const xmlMessage = makeXmlMessage(xmlString)
 		splitAtIndices(xmlMessage, [2, 10, 25, 40]).forEach((fragment) => {
 			expect(fragment.length).toBeGreaterThan(0)
-			reader.processIncomingData(Buffer.from(fragment))
+			reader.processIncomingData(fragment)
 		})
 
 		expect(onMessage).toHaveBeenCalledTimes(1)
@@ -347,7 +317,7 @@ describe('VMixResponseStreamReader', () => {
 			'<vmix><version>27.0.0.49</version><edition>HD</edition><preset>C:\\preset.vmix</preset><inputs><inputs></vmix>'
 		const xmlString2 = '<vmix><version>25.0.0.1</version><edition>4K</edition><inputs><inputs></vmix>'
 
-		reader.processIncomingData(Buffer.from(makeXmlMessage(xmlString) + makeXmlMessage(xmlString2)))
+		reader.processIncomingData(makeXmlMessage(xmlString) + makeXmlMessage(xmlString2))
 
 		expect(onMessage).toHaveBeenCalledTimes(2)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -378,8 +348,8 @@ describe('VMixResponseStreamReader', () => {
 			'<vmix><version>27.0.0.49</version><edition>HD</edition><preset>C:\\preset.vmix</preset><inputs><inputs></vmix>'
 		const xmlString2 = '<vmix><version>25.0.0.1</version><edition>4K</edition><inputs><inputs></vmix>'
 
-		reader.processIncomingData(Buffer.from(makeXmlMessage(xmlString)))
-		reader.processIncomingData(Buffer.from(makeXmlMessage(xmlString2)))
+		reader.processIncomingData(makeXmlMessage(xmlString))
+		reader.processIncomingData(makeXmlMessage(xmlString2))
 
 		expect(onMessage).toHaveBeenCalledTimes(2)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -410,9 +380,9 @@ describe('VMixResponseStreamReader', () => {
 			'<vmix><version>27.0.0.49</version><edition>HD</edition><preset>C:\\preset.vmix</preset><inputs><inputs></vmix>'
 		const xmlString2 = '<vmix><version>25.0.0.1</version><edition>4K</edition><inputs><inputs></vmix>'
 
-		reader.processIncomingData(Buffer.from(makeXmlMessage(xmlString).substring(0, 44)))
+		reader.processIncomingData(makeXmlMessage(xmlString).substring(0, 44))
 		reader.reset()
-		reader.processIncomingData(Buffer.from(makeXmlMessage(xmlString2)))
+		reader.processIncomingData(makeXmlMessage(xmlString2))
 
 		expect(onMessage).toHaveBeenCalledTimes(1)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -435,8 +405,8 @@ describe('VMixResponseStreamReader', () => {
 		const onError = jest.fn()
 		reader.on('error', onError)
 
-		reader.processIncomingData(Buffer.from('VERSION OK 27.0.0.49\r\n'))
-		reader.processIncomingData(Buffer.from('FUNCTION OK Take\r\n'))
+		reader.processIncomingData('VERSION OK 27.0.0.49\r\n')
+		reader.processIncomingData('FUNCTION OK Take\r\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(2)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -466,9 +436,9 @@ describe('VMixResponseStreamReader', () => {
 		const onError = jest.fn()
 		reader.on('error', onError)
 
-		reader.processIncomingData(Buffer.from('VERSION OK 27.0.0.49\r\n'))
-		reader.processIncomingData(Buffer.from('\r\n'))
-		reader.processIncomingData(Buffer.from('FUNCTION OK Take\r\n'))
+		reader.processIncomingData('VERSION OK 27.0.0.49\r\n')
+		reader.processIncomingData('\r\n')
+		reader.processIncomingData('FUNCTION OK Take\r\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(2)
 		expect(onMessage).toHaveBeenNthCalledWith(
@@ -498,9 +468,9 @@ describe('VMixResponseStreamReader', () => {
 		const onError = jest.fn()
 		reader.on('error', onError)
 
-		reader.processIncomingData(Buffer.from('VERSION OK 27.0.0.49\r\n'))
-		reader.processIncomingData(Buffer.from('WASSUP\r\n'))
-		reader.processIncomingData(Buffer.from('FUNCTION OK Take\r\n'))
+		reader.processIncomingData('VERSION OK 27.0.0.49\r\n')
+		reader.processIncomingData('WASSUP\r\n')
+		reader.processIncomingData('FUNCTION OK Take\r\n')
 
 		expect(onMessage).toHaveBeenCalledTimes(2)
 		expect(onMessage).toHaveBeenNthCalledWith(

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmixMock.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmixMock.ts
@@ -157,9 +157,8 @@ function buildResponse(command: string, state?: 'OK' | 'ER', dataOrMessage?: str
 // send every item in the array in a separate `data` event/packet
 function sendData(socket: net.Socket, response: string[]) {
 	for (const packet of response) {
-		const dataBuf = Buffer.from(packet, 'utf-8')
 		orgSetImmediate(() => {
-			socket.mockData(dataBuf)
+			socket.mockData(packet)
 		})
 	}
 }

--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -114,6 +114,12 @@ export class BaseConnection extends EventEmitter<ConnectionEvents> {
 		this._socket.setEncoding('utf-8')
 
 		this._socket.on('data', (data) => {
+			if (typeof data !== 'string') {
+				// this is against the types, but according to the docs the data will be a string
+				// the problem of a character split into chunks in transit should be taken care of
+				// (https://nodejs.org/docs/latest-v12.x/api/stream.html#stream_readable_setencoding_encoding)
+				throw new Error('Received a non-string even though encoding should have been set to utf-8')
+			}
 			this._responseStreamReader.processIncomingData(data)
 		})
 		this._socket.on('connect', () => {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This PR is being opened on behalf of TV 2 Norge.

## Type of Contribution

This is a: 
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
An utf-8 character consisting of more than one byte appearing in a message received from vMix could make the message unprocessable, ~~or turn into a garbled character.~~

## New Behavior
<!--
What is the new behavior?
-->
The vMixResponseStreamReader class now respects multi-byte characters in XML messages.
The assumptions about Socket's 'data' event providing a Buffer are corrected in code and in the tests. 

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->
Details of the fix:
The data length that vMix provides is in bytes, previously incorrectly interpreted as length in characters.
~~The line remainder is now stored as a Buffer in case the arriving data is fragmented mid-character.~~ 

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
