### PR TITLE
Refactor connection management

### DIFF
--- a/packages/quick-tsr/src/tsrHandler.ts
+++ b/packages/quick-tsr/src/tsrHandler.ts
@@ -135,6 +135,6 @@ export class TSRHandler {
 		this.tsr.setDatastore(store)
 	}
 	public async setDevices(devices: { [deviceId: string]: DeviceOptionsAny }): Promise<void> {
-		this.tsr.connectionManager.setConnections(new Map(Object.entries(devices)))
+		this.tsr.connectionManager.setConnections(devices)
 	}
 }

--- a/packages/quick-tsr/src/tsrHandler.ts
+++ b/packages/quick-tsr/src/tsrHandler.ts
@@ -8,7 +8,6 @@ import {
 	Datastore,
 	DeviceStatus,
 	SlowSentCommandInfo,
-	DeviceOptionsBase,
 	SlowFulfilledCommandInfo,
 	DeviceType,
 	CasparCGDevice,
@@ -19,7 +18,6 @@ import { ThreadedClass } from 'threadedclass'
 
 import * as _ from 'underscore'
 import { TSRSettings } from './index'
-import { BaseRemoteDeviceIntegration } from 'timeline-state-resolver/dist/service/remoteDeviceInstance'
 
 /**
  * Represents a connection between Gateway and TSR
@@ -27,12 +25,8 @@ import { BaseRemoteDeviceIntegration } from 'timeline-state-resolver/dist/servic
 export class TSRHandler {
 	private tsr!: Conductor
 
-	private _multiThreaded: boolean | null = null
-
 	// private _timeline: TSRTimeline
 	// private _mappings: Mappings
-
-	private _devices: { [deviceId: string]: BaseRemoteDeviceIntegration<DeviceOptionsBase<any>> } = {}
 
 	constructor() {
 		// nothing
@@ -76,6 +70,29 @@ export class TSRHandler {
 			// todo ?
 		})
 
+		this.tsr.connectionManager.on('connectionEvent:connectionChanged', (deviceId: string, status: DeviceStatus) => {
+			console.log(`Device ${deviceId} status changed: ${JSON.stringify(status)}`)
+		})
+		this.tsr.connectionManager.on(
+			'connectionEvent:slowSentCommand',
+			(_deviceId: string, _info: SlowSentCommandInfo) => {
+				// console.log(`Device ${device.deviceId} slow sent command: ${_info}`)
+			}
+		)
+		this.tsr.connectionManager.on(
+			'connectionEvent:slowFulfilledCommand',
+			(_deviceId: string, _info: SlowFulfilledCommandInfo) => {
+				// console.log(`Device ${device.deviceId} slow fulfilled command: ${_info}`)
+			}
+		)
+		this.tsr.connectionManager.on('connectionEvent:commandReport', (deviceId: string, command: any) => {
+			console.log(`Device ${deviceId} command: ${JSON.stringify(command)}`)
+		})
+		this.tsr.connectionManager.on('connectionEvent:debug', (deviceId: string, ...args: any[]) => {
+			const data = args.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg) : arg))
+			console.log(`Device ${deviceId} debug: ${data}`)
+		})
+
 		await this.tsr.init()
 
 		// this._initialized = true
@@ -90,7 +107,7 @@ export class TSRHandler {
 		else return Promise.resolve()
 	}
 	async logMediaList(): Promise<void> {
-		for (const deviceContainer of this.tsr.getDevices()) {
+		for (const deviceContainer of this.tsr.connectionManager.getConnections()) {
 			if (deviceContainer.deviceType === DeviceType.CASPARCG) {
 				const device = deviceContainer.device as ThreadedClass<CasparCGDevice>
 
@@ -118,94 +135,6 @@ export class TSRHandler {
 		this.tsr.setDatastore(store)
 	}
 	public async setDevices(devices: { [deviceId: string]: DeviceOptionsAny }): Promise<void> {
-		const ps: Array<Promise<void>> = []
-
-		_.each(devices, (deviceOptions: DeviceOptionsAny, deviceId: string) => {
-			const oldDevice = this.tsr.getDevice(deviceId)
-
-			if (!oldDevice) {
-				if (deviceOptions.options) {
-					console.log('Initializing device: ' + deviceId)
-					ps.push(this._addDevice(deviceId, deviceOptions))
-				}
-			} else {
-				if (this._multiThreaded !== null && deviceOptions.isMultiThreaded === undefined) {
-					deviceOptions.isMultiThreaded = this._multiThreaded
-				}
-				if (deviceOptions.options) {
-					let anyChanged = false
-
-					// let oldOptions = (oldDevice.deviceOptions).options || {}
-
-					if (!_.isEqual(oldDevice.deviceOptions, deviceOptions)) {
-						anyChanged = true
-					}
-
-					if (anyChanged) {
-						console.log('Re-initializing device: ' + deviceId)
-						ps.push(this._removeDevice(deviceId).then(async () => this._addDevice(deviceId, deviceOptions)))
-					}
-				}
-			}
-		})
-
-		_.each(this.tsr.getDevices(), (oldDevice: BaseRemoteDeviceIntegration<DeviceOptionsBase<any>>) => {
-			const deviceId = oldDevice.deviceId
-			if (!devices[deviceId]) {
-				console.log('Un-initializing device: ' + deviceId)
-				ps.push(this._removeDevice(deviceId))
-			}
-		})
-
-		await Promise.all(ps)
-	}
-	private async _addDevice(deviceId: string, options: DeviceOptionsAny) {
-		// console.log('Adding device ' + deviceId)
-
-		if (!options.limitSlowSentCommand) options.limitSlowSentCommand = 40
-		if (!options.limitSlowFulfilledCommand) options.limitSlowFulfilledCommand = 100
-
-		try {
-			const device = await this.tsr.addDevice(deviceId, options)
-
-			this._devices[deviceId] = device
-
-			await device.device.on('connectionChanged', ((status: DeviceStatus) => {
-				console.log(`Device ${device.deviceId} status changed: ${JSON.stringify(status)}`)
-			}) as () => void)
-			await device.device.on('slowSentCommand', ((_info: SlowSentCommandInfo) => {
-				// console.log(`Device ${device.deviceId} slow sent command: ${_info}`)
-			}) as () => void)
-			await device.device.on('slowFulfilledCommand', ((_info: SlowFulfilledCommandInfo) => {
-				// console.log(`Device ${device.deviceId} slow fulfilled command: ${_info}`)
-			}) as () => void)
-			await device.device.on('commandReport', ((command: any) => {
-				console.log(`Device ${device.deviceId} command: ${JSON.stringify(command)}`)
-			}) as () => void)
-			await device.device.on('debug', (...args: any[]) => {
-				const data = args.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg) : arg))
-				console.log(`Device ${device.deviceId} debug: ${data}`)
-			})
-			// also ask for the status now, and update:
-			// onConnectionChanged(await device.device.getStatus())
-		} catch (e) {
-			console.error(`Error when adding device "${deviceId}"`, e)
-		}
-	}
-	private async _removeDevice(deviceId: string) {
-		try {
-			await this.tsr.removeDevice(deviceId)
-		} catch (e) {
-			console.error('Error when removing tsr device: ' + e)
-		}
-
-		if (this._devices[deviceId]) {
-			try {
-				await this._devices[deviceId].device.terminate()
-			} catch (e) {
-				console.error('Error when removing device: ' + e)
-			}
-		}
-		delete this._devices[deviceId]
+		this.tsr.connectionManager.setConnections(new Map(Object.entries(devices)))
 	}
 }

--- a/packages/quick-tsr/src/tsrHandler.ts
+++ b/packages/quick-tsr/src/tsrHandler.ts
@@ -16,7 +16,6 @@ import {
 } from 'timeline-state-resolver'
 import { ThreadedClass } from 'threadedclass'
 
-import * as _ from 'underscore'
 import { TSRSettings } from './index'
 
 /**

--- a/packages/timeline-state-resolver/examples/CasparcgVideoPlayES6example.js
+++ b/packages/timeline-state-resolver/examples/CasparcgVideoPlayES6example.js
@@ -14,7 +14,7 @@ tsrConductor
 	.init()
 	.then(() => {
 		// Add devices to the TSR-conductor:
-		return tsr.connectionManager.setConnections({
+		return tsrConductor.connectionManager.setConnections({
 			casparcg0: {
 				type: DeviceType.CASPARCG,
 				options: {

--- a/packages/timeline-state-resolver/examples/CasparcgVideoPlayES6example.js
+++ b/packages/timeline-state-resolver/examples/CasparcgVideoPlayES6example.js
@@ -14,11 +14,13 @@ tsrConductor
 	.init()
 	.then(() => {
 		// Add devices to the TSR-conductor:
-		return tsrConductor.addDevice('casparcg0', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: 'localhost',
-				port: 5250,
+		return tsr.connectionManager.setConnections({
+			casparcg0: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: 'localhost',
+					port: 5250,
+				},
 			},
 		})
 	})

--- a/packages/timeline-state-resolver/examples/playVideoInCaspar.ts
+++ b/packages/timeline-state-resolver/examples/playVideoInCaspar.ts
@@ -12,11 +12,13 @@ tsr.on('debug', (deviceId, cmd) => console.log('debug', deviceId, cmd))
 const a = async function () {
 	await tsr.init()
 
-	await tsr.addDevice('casparcg0', {
-		type: DeviceType.CASPARCG,
-		options: {
-			host: '127.0.0.1',
-			// port: 5250
+	tsr.connectionManager.setConnections({
+		casparcg0: {
+			type: DeviceType.CASPARCG,
+			options: {
+				host: '127.0.0.1',
+				// port: 5250
+			},
 		},
 	})
 

--- a/packages/timeline-state-resolver/examples/testChangeTimelineQuickly.ts
+++ b/packages/timeline-state-resolver/examples/testChangeTimelineQuickly.ts
@@ -10,11 +10,13 @@ tsr.on('error', (e) => console.log('error', e))
 const a = async function () {
 	await tsr.init()
 
-	await tsr.addDevice('casparcg0', {
-		type: DeviceType.CASPARCG,
-		options: {
-			host: '127.0.0.1',
-			// port: 5250
+	tsr.connectionManager.setConnections({
+		casparcg0: {
+			type: DeviceType.CASPARCG,
+			options: {
+				host: '127.0.0.1',
+				// port: 5250
+			},
 		},
 	})
 

--- a/packages/timeline-state-resolver/src/__mocks__/osc.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/osc.ts
@@ -9,7 +9,7 @@ export class UDPPort extends EventEmitter {
 		this.emit('ready')
 	}
 
-	send({ address }) {
+	send({ address }: { address: string }) {
 		orgSetTimeout(() => {
 			if (MockOSC.connectionIsGood) {
 				if (address === '/state/full') {
@@ -21,11 +21,18 @@ export class UDPPort extends EventEmitter {
 								value: `{ "channel": [{
 								"faderLevel": 0.75,
 								"pgmOn": false,
-								"pstOn": false
+								"pstOn": false,
+								"showChannel": true
 							}, {
 								"faderLevel": 0.75,
 								"pgmOn": false,
-								"pstOn": false
+								"pstOn": false,
+								"showChannel": true
+							}, {
+								"faderLevel": 0.75,
+								"pgmOn": false,
+								"pstOn": false,
+								"showChannel": true
 							}] }`,
 							},
 						],

--- a/packages/timeline-state-resolver/src/__tests__/conductor.spec.ts
+++ b/packages/timeline-state-resolver/src/__tests__/conductor.spec.ts
@@ -27,8 +27,6 @@ jest.mock('../service/DeviceInstance', () => ({
 
 import { Conductor, TimelineTriggerTimeResult } from '../conductor'
 import type { DeviceInstanceWrapper } from '../service/DeviceInstance'
-import { DeviceOptionsAnyInternal } from '..'
-import { ConnectionManager } from '../service/ConnectionManager'
 
 describe('Conductor', () => {
 	const mockTime = new MockTime()

--- a/packages/timeline-state-resolver/src/__tests__/lib.ts
+++ b/packages/timeline-state-resolver/src/__tests__/lib.ts
@@ -1,8 +1,50 @@
+import { DeviceOptionsAnyInternal } from '../conductor'
+import { ConnectionManager } from '../service/ConnectionManager'
+
 /**
  * Just a wrapper to :any type, to be used in tests only
  */
 export function getMockCall<T>(fcn: jest.Mock<T>, callIndex: number, paramIndex: number): any {
 	return fcn.mock.calls[callIndex][paramIndex]
+}
+export async function addConnections(
+	connManager: ConnectionManager,
+	connections: Record<string, DeviceOptionsAnyInternal>
+): Promise<void> {
+	const connectionIds = Object.keys(connections)
+	const addedConns: string[] = []
+
+	let resolveAdded: undefined | (() => void) = undefined
+	const psAdded = new Promise<void>((resolveCb) => (resolveAdded = resolveCb))
+	connManager.on('connectionAdded', (id) => {
+		addedConns.push(id)
+
+		if (resolveAdded && addedConns.length === connectionIds.length) resolveAdded()
+	})
+
+	connManager.setConnections(new Map(Object.entries(connections)))
+
+	await psAdded
+}
+
+export async function removeConnections(
+	connManager: ConnectionManager,
+	connections: Record<string, DeviceOptionsAnyInternal>,
+	toBeRemoved: string[]
+): Promise<void> {
+	const addedConns: string[] = []
+
+	let resolveAdded: undefined | (() => void) = undefined
+	const psAdded = new Promise<void>((resolveCb) => (resolveAdded = resolveCb))
+	connManager.on('connectionRemoved', (id) => {
+		addedConns.push(id)
+
+		if (resolveAdded && addedConns.length === toBeRemoved.length) resolveAdded()
+	})
+
+	connManager.setConnections(new Map(Object.entries(connections)))
+
+	await psAdded
 }
 
 // Excend jest.expect in functionality and typings

--- a/packages/timeline-state-resolver/src/__tests__/lib.ts
+++ b/packages/timeline-state-resolver/src/__tests__/lib.ts
@@ -1,5 +1,6 @@
 import { DeviceOptionsAnyInternal } from '../conductor'
 import { ConnectionManager } from '../service/ConnectionManager'
+import { MockTime } from './mockTime'
 
 /**
  * Just a wrapper to :any type, to be used in tests only
@@ -82,6 +83,57 @@ declare global {
 	namespace jest {
 		interface Expect {
 			toBeCloseTo(target: number, diff: number): any
+		}
+	}
+}
+/** setTimeout (not affected by jest.fakeTimers) */
+const setTimeoutOrg = setTimeout
+/** Sleep for a  */
+export function waitTime(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeoutOrg(resolve, ms))
+}
+
+/** An actual monotonic time, not affected by jest.fakeTimers */
+export const realTimeNow = performance.now
+/**
+ * Executes {expectFcn} intermittently until it doesn't throw anymore.
+ * Waits up to {maxWaitTime} ms, then throws the latest error.
+ * Useful in unit-tests as a way to wait until a predicate is fulfilled.
+ */
+export async function waitUntil(
+	expectFcn: () => void | Promise<void>,
+	maxWaitTime: number,
+	mockTime?: MockTime
+): Promise<void> {
+	const startTime = realTimeNow()
+
+	const previousErrors: string[] = []
+
+	while (true) {
+		mockTime?.advanceTimeTicks(100)
+		await waitTime(100)
+		try {
+			await Promise.resolve(expectFcn())
+			return
+		} catch (err) {
+			const errorStr = `${err}`
+			if (previousErrors.length) {
+				const previousError = previousErrors[previousErrors.length - 1]
+				if (errorStr !== previousError) {
+					previousErrors.push(errorStr)
+				}
+			} else {
+				previousErrors.push(errorStr)
+			}
+
+			const waitedTime = realTimeNow() - startTime
+			if (waitedTime > maxWaitTime) {
+				console.log(`waitUntil: waited for ${waitedTime} ms, giving up (maxWaitTime: ${maxWaitTime}).`)
+				console.log(`Previous errors: \n${previousErrors.join('\n')}`)
+
+				throw err
+			}
+			// else ignore error and try again later
 		}
 	}
 }

--- a/packages/timeline-state-resolver/src/__tests__/lib.ts
+++ b/packages/timeline-state-resolver/src/__tests__/lib.ts
@@ -16,7 +16,7 @@ export async function addConnections(
 
 	let resolveAdded: undefined | (() => void) = undefined
 	const psAdded = new Promise<void>((resolveCb) => (resolveAdded = resolveCb))
-	connManager.on('connectionAdded', (id) => {
+	connManager.on('connectionInitialised', (id) => {
 		addedConns.push(id)
 
 		if (resolveAdded && addedConns.length === connectionIds.length) resolveAdded()

--- a/packages/timeline-state-resolver/src/__tests__/lib.ts
+++ b/packages/timeline-state-resolver/src/__tests__/lib.ts
@@ -89,12 +89,12 @@ declare global {
 /** setTimeout (not affected by jest.fakeTimers) */
 const setTimeoutOrg = setTimeout
 /** Sleep for a  */
-export function waitTime(ms: number): Promise<void> {
+export async function waitTime(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeoutOrg(resolve, ms))
 }
 
-/** An actual monotonic time, not affected by jest.fakeTimers */
-export const realTimeNow = performance.now
+/** The current time, not affected by jest.fakeTimers */
+export const realTimeNow = Date.now.bind(Date)
 /**
  * Executes {expectFcn} intermittently until it doesn't throw anymore.
  * Waits up to {maxWaitTime} ms, then throws the latest error.
@@ -109,8 +109,9 @@ export async function waitUntil(
 
 	const previousErrors: string[] = []
 
+	// eslint-disable-next-line no-constant-condition
 	while (true) {
-		mockTime?.advanceTimeTicks(100)
+		await mockTime?.advanceTimeTicks(100)
 		await waitTime(100)
 		try {
 			await Promise.resolve(expectFcn())

--- a/packages/timeline-state-resolver/src/__tests__/lib.ts
+++ b/packages/timeline-state-resolver/src/__tests__/lib.ts
@@ -18,7 +18,6 @@ export async function addConnections(
 	let resolveAdded: undefined | (() => void) = undefined
 	const psAdded = new Promise<void>((resolveCb) => (resolveAdded = resolveCb))
 	const cb = (id: string) => {
-		console.log('got ' + id, 'expect ' + connectionIds)
 		addedConns.push(id)
 
 		if (resolveAdded && addedConns.length === connectionIds.length) {
@@ -36,7 +35,7 @@ export async function addConnections(
 		connManager.on('connectionAdded', cb)
 	}
 
-	connManager.setConnections(new Map(Object.entries(connections)))
+	connManager.setConnections(connections)
 
 	await psAdded
 }
@@ -56,7 +55,7 @@ export async function removeConnections(
 		if (resolveAdded && addedConns.length === toBeRemoved.length) resolveAdded()
 	})
 
-	connManager.setConnections(new Map(Object.entries(connections)))
+	connManager.setConnections(connections)
 
 	await psAdded
 }

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -340,7 +340,7 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 		if (this._triggerSendStartStopCallbacksTimeout) clearTimeout(this._triggerSendStartStopCallbacksTimeout)
 
 		// remove all connections:
-		this.connectionManager.setConnections(new Map())
+		this.connectionManager.setConnections({})
 	}
 
 	/**

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -332,15 +332,15 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 	}
 
 	/**
-	 * Remove all devices
+	 * Remove all connections
 	 */
 	public async destroy(): Promise<void> {
 		clearTimeout(this._interval)
 
 		if (this._triggerSendStartStopCallbacksTimeout) clearTimeout(this._triggerSendStartStopCallbacksTimeout)
 
-		// todo - reenable this
-		// await this._mapAllDevices(true, async (d) => this.removeDevice(d.deviceId))
+		// remove all connections:
+		this.connectionManager.setConnections(new Map())
 	}
 
 	/**

--- a/packages/timeline-state-resolver/src/integrations/casparCG/__tests__/casparcg.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/__tests__/casparcg.spec.ts
@@ -13,7 +13,7 @@ import {
 	MappingCasparCGType,
 } from 'timeline-state-resolver-types'
 import { MockTime } from '../../../__tests__/mockTime'
-import { getMockCall } from '../../../__tests__/lib'
+import { addConnections, getMockCall } from '../../../__tests__/lib'
 import { Commands } from 'casparcg-connection'
 
 // usage logCalls(commandReceiver0)
@@ -51,13 +51,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -129,13 +131,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -196,14 +200,16 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
-				fps: 50,
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+					fps: 50,
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -278,13 +284,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
 		myConductor.setTimelineAndMappings(
@@ -351,13 +359,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
 		// await mockTime.advanceTimeToTicks(10050)
@@ -440,13 +450,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
 		await mockTime.advanceTimeToTicks(10050)
@@ -519,13 +531,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
 		await mockTime.advanceTimeToTicks(10050)
@@ -599,18 +613,20 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
-		const deviceContainer = myConductor.getDevice('myCCG')
-		const device = deviceContainer!.device
-		await device['_ccgState']
+		const connContainer = myConductor.connectionManager.getConnection('myCCG')
+		const conn = connContainer!.device
+		await conn['_ccgState']
 
 		await mockTime.advanceTimeToTicks(10050)
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)
@@ -715,13 +731,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
 		// Check that no commands has been sent:
@@ -834,13 +852,15 @@ describe('CasparCG', () => {
 			console.warn(msg)
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
 		// Check that no commands has been sent:
@@ -972,13 +992,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
@@ -1077,13 +1099,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
 		expect(mockTime.getCurrentTime()).toEqual(10000)
@@ -1181,13 +1205,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
 		await mockTime.advanceTimeToTicks(10050)
@@ -1281,13 +1307,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 
 		await mockTime.advanceTimeToTicks(10050)
@@ -1370,13 +1398,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -1454,14 +1484,16 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
-				retryInterval: undefined, // disable retries explicitly, we will manually trigger them
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+					retryInterval: undefined, // disable retries explicitly, we will manually trigger them
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 		myConductor.setTimelineAndMappings([], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
@@ -1470,8 +1502,8 @@ describe('CasparCG', () => {
 
 		commandReceiver0.mockClear()
 
-		const deviceContainer = myConductor.getDevice('myCCG')
-		const device = deviceContainer!.device
+		const connContainer = myConductor.connectionManager.getConnection('myCCG')
+		const conn = connContainer!.device
 
 		myConductor.setTimelineAndMappings([
 			{
@@ -1513,7 +1545,7 @@ describe('CasparCG', () => {
 		// advance to half way
 		await mockTime.advanceTimeToTicks(10700)
 		// call the retry mechanism
-		await (device as any)._assertIntendedState()
+		await (conn as any)._assertIntendedState()
 		await mockTime.advanceTimeToTicks(10800)
 
 		expect(commandReceiver0).toHaveBeenCalledTimes(2)
@@ -1530,13 +1562,13 @@ describe('CasparCG', () => {
 		// apply command to internal ccg-state
 		const resCommand = getMockCall(commandReceiver0, 1, 1)
 		// @ts-ignore
-		await device._changeTrackedStateFromCommand(
+		await conn._changeTrackedStateFromCommand(
 			resCommand,
 			{ responseCode: 202, command: resCommand.command },
 			mockTime.getCurrentTime()
 		)
 		// trigger retry mechanism
-		await (device as any)._assertIntendedState()
+		await (conn as any)._assertIntendedState()
 		await mockTime.advanceTimeToTicks(10900)
 		// no retries done
 		expect(commandReceiver0).toHaveBeenCalledTimes(2)
@@ -1553,7 +1585,7 @@ describe('CasparCG', () => {
 		// advance time to after clip:
 		await mockTime.advanceTimeToTicks(11700)
 		// call the retry mechanism
-		await (device as any)._assertIntendedState()
+		await (conn as any)._assertIntendedState()
 		await mockTime.advanceTimeToTicks(11800)
 		// no retries issued
 		expect(commandReceiver0).toHaveBeenCalledTimes(3)
@@ -1581,14 +1613,16 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init()
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
-				retryInterval: undefined, // disable retries explicitly, we will manually trigger them
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+					retryInterval: undefined, // disable retries explicitly, we will manually trigger them
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 		myConductor.setTimelineAndMappings([], myLayerMapping)
 		await mockTime.advanceTimeToTicks(10100)
@@ -1597,8 +1631,8 @@ describe('CasparCG', () => {
 
 		commandReceiver0.mockClear()
 
-		const deviceContainer = myConductor.getDevice('myCCG')
-		const device = deviceContainer!.device
+		const connContainer = myConductor.connectionManager.getConnection('myCCG')
+		const conn = connContainer!.device
 
 		myConductor.setTimelineAndMappings([
 			{
@@ -1658,7 +1692,7 @@ describe('CasparCG', () => {
 		// @ts-ignore
 		const resCommand = getMockCall(commandReceiver0, 0, 1)
 		// @ts-ignore
-		await device._changeTrackedStateFromCommand(
+		await conn._changeTrackedStateFromCommand(
 			resCommand,
 			{ responseCode: 202, command: resCommand.command },
 			mockTime.getCurrentTime()
@@ -1672,7 +1706,7 @@ describe('CasparCG', () => {
 		// advance to half way
 		await mockTime.advanceTimeToTicks(10700)
 		// call the retry mechanism
-		await (device as any)._assertIntendedState()
+		await (conn as any)._assertIntendedState()
 		// still no retries as empty always plays
 		expect(commandReceiver0).toHaveBeenCalledTimes(1)
 
@@ -1681,7 +1715,7 @@ describe('CasparCG', () => {
 		// advance time to after clip:
 		await mockTime.advanceTimeToTicks(20700)
 		// call the retry mechanism
-		await (device as any)._assertIntendedState()
+		await (conn as any)._assertIntendedState()
 		await mockTime.advanceTimeToTicks(20800)
 		// no retries issued
 		expect(commandReceiver0).toHaveBeenCalledTimes(1)
@@ -1710,13 +1744,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -1806,13 +1842,15 @@ describe('CasparCG', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('myCCG', {
-			type: DeviceType.CASPARCG,
-			options: {
-				host: '127.0.0.1',
+		await addConnections(myConductor.connectionManager, {
+			myCCG: {
+				type: DeviceType.CASPARCG,
+				options: {
+					host: '127.0.0.1',
+				},
+				commandReceiver: commandReceiver0,
+				skipVirginCheck: true,
 			},
-			commandReceiver: commandReceiver0,
-			skipVirginCheck: true,
 		})
 		await mockTime.advanceTimeToTicks(10100)
 

--- a/packages/timeline-state-resolver/src/integrations/casparCG/__tests__/casparcg.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/__tests__/casparcg.spec.ts
@@ -863,6 +863,8 @@ describe('CasparCG', () => {
 			},
 		})
 
+		await mockTime.advanceTimeTicks(100) // let the device settle
+
 		// Check that no commands has been sent:
 		expect(commandReceiver0).toHaveBeenCalledTimes(0)
 

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -123,6 +123,7 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			host: initOptions.host,
 			port: initOptions.port,
 		})
+		let firstConnect = true
 
 		this._ccg.on('connect', () => {
 			this.makeReady(false) // always make sure timecode is correct, setting it can never do bad
@@ -183,16 +184,15 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 					return true
 				})
 				.then((doResync) => {
-					if (this.deviceOptions.skipVirginCheck) return
-
 					// Finally we can report it as connected
 					this._connected = true
 					this._connectionChanged()
 
-					if (doResync) {
+					if (firstConnect || doResync) {
+						firstConnect = false
 						this._currentState = { channels: {} }
 						this.clearStates()
-						this.emit('resetResolver')
+						this.emit('resyncStates')
 					}
 				})
 				.catch((e) => {

--- a/packages/timeline-state-resolver/src/integrations/lawo/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/lawo/index.ts
@@ -23,7 +23,6 @@ export class LawoDevice extends Device<LawoOptions, LawoState, LawoCommandWithCo
 		this._lawo = new LawoConnection(options, this.context.getCurrentTime)
 		this._lawo.on('error', (e) => this.context.logger.error('Lawo.LawoConnection', e))
 		this._lawo.on('debug', (...debug) => this.context.logger.debug('Lawo.LawoConnection', ...debug))
-		this._lawo.on('debug', (...debug) => console.log('Lawo.LawoConnection', ...debug))
 		this._lawo.on('connected', (firstConnection) => {
 			if (firstConnection) {
 				// reset state

--- a/packages/timeline-state-resolver/src/integrations/multiOsc/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/multiOsc/index.ts
@@ -77,7 +77,9 @@ export class MultiOSCMessageDevice extends Device<MultiOSCOptions, MultiOSCDevic
 		}
 
 		// note - we reset here but might still be missing some connections from tcp devices, not worth fixing right now
-		this.context.resetToState(Object.fromEntries(Object.keys(this._connections).map((id) => [id, {}])))
+		this.context
+			.resetToState(Object.fromEntries(Object.keys(this._connections).map((id) => [id, {}])))
+			.catch((e) => this.context.logger.warning('Failed to reset state: ' + e))
 
 		return true
 	}

--- a/packages/timeline-state-resolver/src/integrations/multiOsc/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/multiOsc/index.ts
@@ -76,6 +76,9 @@ export class MultiOSCMessageDevice extends Device<MultiOSCOptions, MultiOSCDevic
 			})
 		}
 
+		// note - we reset here but might still be missing some connections from tcp devices, not worth fixing right now
+		this.context.resetToState(Object.fromEntries(Object.keys(this._connections).map((id) => [id, {}])))
+
 		return true
 	}
 

--- a/packages/timeline-state-resolver/src/integrations/osc/__tests__/osc.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/osc/__tests__/osc.spec.ts
@@ -24,6 +24,12 @@ jest.mock('osc', () => {
 				on: (event: string, listener: (...args: any[]) => void) => {
 					SOCKET_EVENTS.set(event, listener)
 				},
+				once: (event: string, listener: (...args: any[]) => void) => {
+					SOCKET_EVENTS.set(event, (...args: any[]) => {
+						SOCKET_EVENTS.delete(event)
+						return listener(...args)
+					})
+				},
 				close: jest.fn(),
 			}
 		}),

--- a/packages/timeline-state-resolver/src/integrations/osc/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/osc/index.ts
@@ -56,9 +56,21 @@ export class OscDevice extends Device<OSCOptions, OscDeviceState, OscCommandWith
 			})
 			this._oscClient = client
 			client.open() // creates client.socket
+			let firstConnect = true
 			client.socket.on('connect', () => {
 				this._oscClientStatus = 'connected'
-				this.context.connectionChanged(this.getStatus())
+				if (firstConnect) {
+					// note - perhaps we could resend the commands every time we reconnect? or that could be a device option
+					firstConnect = false
+					this.context.connectionChanged(this.getStatus())
+					this.context
+						.resetToState({})
+						.catch((e) =>
+							this.context.logger.warning(
+								'Failed to reset to state after first connection, device may be in unknown state (reason: ' + e + ')'
+							)
+						)
+				}
 			})
 			client.socket.on('close', () => {
 				this._oscClientStatus = 'disconnected'
@@ -73,6 +85,15 @@ export class OscDevice extends Device<OSCOptions, OscDeviceState, OscCommandWith
 				remoteAddress: options.host,
 				remotePort: options.port,
 				metadata: true,
+			})
+			this._oscClient.once('ready', () => {
+				this.context
+					.resetToState({})
+					.catch((e) =>
+						this.context.logger.warning(
+							'Failed to reset to state after first connection, device may be in unknown state (reason: ' + e + ')'
+						)
+					)
 			})
 			this._oscClient.open()
 		} else {

--- a/packages/timeline-state-resolver/src/integrations/pharos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/pharos/index.ts
@@ -58,7 +58,7 @@ export class PharosDevice extends Device<PharosOptions, PharosState, PharosComma
 					.getProjectInfo()
 					.then((info) => {
 						this.context.logger.info(`Current project: ${info.name}`)
-						this.context.resetToState({})
+						this.context.resetToState({}).catch((e) => this.context.logger.error('Failed to reset state', e))
 					})
 					.catch((e) => this.context.logger.error('Failed to query project', e))
 			})

--- a/packages/timeline-state-resolver/src/integrations/pharos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/pharos/index.ts
@@ -58,6 +58,7 @@ export class PharosDevice extends Device<PharosOptions, PharosState, PharosComma
 					.getProjectInfo()
 					.then((info) => {
 						this.context.logger.info(`Current project: ${info.name}`)
+						this.context.resetToState({})
 					})
 					.catch((e) => this.context.logger.error('Failed to query project', e))
 			})

--- a/packages/timeline-state-resolver/src/integrations/quantel/__tests__/quantelGatewayMock.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/__tests__/quantelGatewayMock.ts
@@ -29,9 +29,8 @@ export function setupQuantelGatewayMock() {
 		},
 	}
 
-	// @ts-ignore: not logging
 	const onRequest = jest.fn((_type: string, _url: string) => {
-		// console.log('onRequest', type, url)
+		// nothing
 	})
 
 	const onRequestRaw = jest.fn((type: string, url: string) => {
@@ -223,7 +222,6 @@ async function handleRequest(
 				message: `ISA URL not provided`,
 				stack: '',
 			}
-			// console.log(type, resource)
 
 			urlRoute(type, resource, {
 				// @ts-ignore: no need for params
@@ -837,7 +835,6 @@ async function handleRequest(
 				},
 			})
 				.then((body) => {
-					// console.log('got responding:', type, resource, body)
 					resolve({
 						statusCode: quantelServer.requestReturnsOK ? 200 : 500,
 						// body: JSON.stringify(body)

--- a/packages/timeline-state-resolver/src/integrations/quantel/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/index.ts
@@ -74,16 +74,31 @@ export class QuantelDevice extends Device<QuantelOptions, QuantelState, QuantelC
 			.init(options.gatewayUrl, isaURLs, options.zoneId, options.serverId)
 			.then(() => {
 				this._quantel.monitorServerStatus((connected: boolean) => {
-					if (!this._disconnectedSince && connected === false && options.suppressDisconnectTime) {
+					if (!this._disconnectedSince && connected === false) {
 						this._disconnectedSince = Date.now()
 
-						// trigger another update after debounce
-						setTimeout(() => {
-							if (!this._quantel.connected) {
-								this.context.connectionChanged(this.getStatus())
-							}
-						}, options.suppressDisconnectTime)
+						if (options.suppressDisconnectTime) {
+							// trigger another update after debounce
+							setTimeout(() => {
+								if (!this._quantel.connected) {
+									this.context.connectionChanged(this.getStatus())
+								}
+							}, options.suppressDisconnectTime)
+						}
 					} else if (connected === true) {
+						if (!this._disconnectedSince) {
+							// this must be our first time connecting, so let's resend any commands we missed
+							this.context
+								.resetToState({ time: 0, port: {} })
+								.catch((e) =>
+									this.context.logger.warning(
+										'Failed to reset to state after first connection, device may be in unknown state (reason: ' +
+											e +
+											')'
+									)
+								)
+						}
+
 						this._disconnectedSince = undefined
 					}
 

--- a/packages/timeline-state-resolver/src/integrations/shotoku/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/shotoku/index.ts
@@ -48,6 +48,15 @@ export class ShotokuDevice extends Device<ShotokuOptions, ShotokuDeviceState, Sh
 
 		this._shotoku
 			.connect(options.host, options.port)
+			.then(() => {
+				this.context
+					.resetToState({ shots: {}, sequences: {} })
+					.catch((e) =>
+						this.context.logger.warning(
+							'Failed to reset to state after first connection, device may be in unknown state (reason: ' + e + ')'
+						)
+					)
+			})
 			.catch((e) => this.context.logger.debug('Shotoku device failed initial connection attempt', e))
 
 		return true

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
@@ -13,7 +13,7 @@ const MockOSC = OSC.MockOSC
 import { MockTime } from '../../../__tests__/mockTime'
 import { ThreadedClass } from 'threadedclass'
 import { SisyfosMessageDevice } from '../../../integrations/sisyfos'
-import { getMockCall } from '../../../__tests__/lib'
+import { addConnections, getMockCall } from '../../../__tests__/lib'
 
 describe('Sisyfos', () => {
 	jest.mock('osc', () => OSC)
@@ -82,18 +82,20 @@ describe('Sisyfos', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('mySisyfos', {
-			type: DeviceType.SISYFOS,
-			options: {
-				host: '192.168.0.10',
-				port: 8900,
+		await addConnections(myConductor.connectionManager, {
+			mySisyfos: {
+				type: DeviceType.SISYFOS,
+				options: {
+					host: '192.168.0.10',
+					port: 8900,
+				},
+				commandReceiver: commandReceiver0,
 			},
-			commandReceiver: commandReceiver0,
 		})
 		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
-		const deviceContainer = myConductor.getDevice('mySisyfos')
+		const deviceContainer = myConductor.connectionManager.getConnection('mySisyfos')
 		const device = deviceContainer!.device as ThreadedClass<SisyfosMessageDevice>
 
 		// Check that no commands has been scheduled:
@@ -309,18 +311,20 @@ describe('Sisyfos', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('mySisyfos', {
-			type: DeviceType.SISYFOS,
-			options: {
-				host: '192.168.0.10',
-				port: 8900,
+		await addConnections(myConductor.connectionManager, {
+			mySisyfos: {
+				type: DeviceType.SISYFOS,
+				options: {
+					host: '192.168.0.10',
+					port: 8900,
+				},
+				commandReceiver: commandReceiver0,
 			},
-			commandReceiver: commandReceiver0,
 		})
 		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
-		const deviceContainer = myConductor.getDevice('mySisyfos')
+		const deviceContainer = myConductor.connectionManager.getConnection('mySisyfos')
 		const device = deviceContainer!.device as ThreadedClass<SisyfosMessageDevice>
 
 		// Check that no commands has been scheduled:
@@ -535,18 +539,20 @@ describe('Sisyfos', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('mySisyfos', {
-			type: DeviceType.SISYFOS,
-			options: {
-				host: '192.168.0.10',
-				port: 8900,
+		await addConnections(myConductor.connectionManager, {
+			mySisyfos: {
+				type: DeviceType.SISYFOS,
+				options: {
+					host: '192.168.0.10',
+					port: 8900,
+				},
+				commandReceiver: commandReceiver0,
 			},
-			commandReceiver: commandReceiver0,
 		})
 		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
-		const deviceContainer = myConductor.getDevice('mySisyfos')
+		const deviceContainer = myConductor.connectionManager.getConnection('mySisyfos')
 		const device = deviceContainer!.device as ThreadedClass<SisyfosMessageDevice>
 
 		// Check that no commands has been scheduled:
@@ -673,18 +679,20 @@ describe('Sisyfos', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('mySisyfos', {
-			type: DeviceType.SISYFOS,
-			options: {
-				host: '192.168.0.10',
-				port: 8900,
+		await addConnections(myConductor.connectionManager, {
+			mySisyfos: {
+				type: DeviceType.SISYFOS,
+				options: {
+					host: '192.168.0.10',
+					port: 8900,
+				},
+				commandReceiver: commandReceiver0,
 			},
-			commandReceiver: commandReceiver0,
 		})
 		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
-		const deviceContainer = myConductor.getDevice('mySisyfos')
+		const deviceContainer = myConductor.connectionManager.getConnection('mySisyfos')
 		const device = deviceContainer!.device as ThreadedClass<SisyfosMessageDevice>
 
 		// Check that no commands has been scheduled:
@@ -891,18 +899,20 @@ describe('Sisyfos', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('mySisyfos', {
-			type: DeviceType.SISYFOS,
-			options: {
-				host: '192.168.0.10',
-				port: 8900,
+		await addConnections(myConductor.connectionManager, {
+			mySisyfos: {
+				type: DeviceType.SISYFOS,
+				options: {
+					host: '192.168.0.10',
+					port: 8900,
+				},
+				commandReceiver: commandReceiver0,
 			},
-			commandReceiver: commandReceiver0,
 		})
 		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
-		const deviceContainer = myConductor.getDevice('mySisyfos')
+		const deviceContainer = myConductor.connectionManager.getConnection('mySisyfos')
 		const device = deviceContainer!.device as ThreadedClass<SisyfosMessageDevice>
 
 		// Check that no commands has been scheduled:
@@ -1041,17 +1051,19 @@ describe('Sisyfos', () => {
 		})
 		// myConductor.setTimelineAndMappings([], myChannelMapping)
 		await myConductor.init()
-		await myConductor.addDevice('mySisyfos', {
-			type: DeviceType.SISYFOS,
-			options: {
-				host: '127.0.0.1',
-				port: 1234,
+		await addConnections(myConductor.connectionManager, {
+			mySisyfos: {
+				type: DeviceType.SISYFOS,
+				options: {
+					host: '192.168.0.10',
+					port: 8900,
+				},
+				commandReceiver: commandReceiver0,
 			},
-			commandReceiver: commandReceiver0,
 		})
 		await mockTime.advanceTimeToTicks(10100)
 
-		const deviceContainer = myConductor.getDevice('mySisyfos')
+		const deviceContainer = myConductor.connectionManager.getConnection('mySisyfos')
 		const device = deviceContainer!.device as ThreadedClass<SisyfosMessageDevice>
 
 		const onConnectionChanged = jest.fn()

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -88,7 +88,11 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 			this.emit('resetResolver')
 		})
 
-		return this._sisyfos.connect(initOptions.host, initOptions.port).then(() => true)
+		this._sisyfos
+			.connect(initOptions.host, initOptions.port)
+			.catch((e) => this.emit('error', 'Failed to initialise Sisyfos connection', e))
+
+		return true
 	}
 	/** Called by the Conductor a bit before a .handleState is called */
 	prepareForHandleState(newStateTime: number) {

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -90,6 +90,11 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 
 		this._sisyfos
 			.connect(initOptions.host, initOptions.port)
+			.then(() => {
+				// process any states that we missed
+				this.clearStates()
+				this.emit('resyncStates')
+			})
 			.catch((e) => this.emit('error', 'Failed to initialise Sisyfos connection', e))
 
 		return true

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -85,16 +85,11 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 	async init(initOptions: SisyfosOptions): Promise<boolean> {
 		this._sisyfos.once('initialized', () => {
 			this.setState(this.getDeviceState(false), this.getCurrentTime())
-			this.emit('resetResolver')
+			this.emit('resyncStates')
 		})
 
 		this._sisyfos
 			.connect(initOptions.host, initOptions.port)
-			.then(() => {
-				// process any states that we missed
-				this.clearStates()
-				this.emit('resyncStates')
-			})
 			.catch((e) => this.emit('error', 'Failed to initialise Sisyfos connection', e))
 
 		return true
@@ -199,7 +194,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 
 		this._doOnTime.clearQueueNowAndAfter(this.getCurrentTime())
 		this._sisyfos.reInitialize()
-		this._sisyfos.on('initialized', () => {
+		this._sisyfos.once('initialized', () => {
 			if (resync) {
 				this._resyncing = false
 				const targetState = this.getState(this.getCurrentTime())
@@ -209,7 +204,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 				}
 			} else {
 				this.setState(this.getDeviceState(false), this.getCurrentTime())
-				this.emit('resetResolver')
+				this.emit('resyncStates')
 			}
 		})
 

--- a/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
@@ -89,7 +89,9 @@ export class SofieChefDevice extends Device<SofieChefOptions, SofieChefState, So
 	async init(initOptions: SofieChefOptions): Promise<boolean> {
 		// This is where we would do initialization, like connecting to the devices, etc
 		this.initOptions = initOptions
-		await this._setupWSConnection()
+
+		this._setupWSConnection().catch((e) => this.context.logger.error('Failed to initialise Sofie Chef connection', e))
+
 		return true
 	}
 	private async _setupWSConnection() {

--- a/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
@@ -90,7 +90,12 @@ export class SofieChefDevice extends Device<SofieChefOptions, SofieChefState, So
 		// This is where we would do initialization, like connecting to the devices, etc
 		this.initOptions = initOptions
 
-		this._setupWSConnection().catch((e) => this.context.logger.error('Failed to initialise Sofie Chef connection', e))
+		this._setupWSConnection()
+			.then(() => {
+				// assume empty state on start (would be nice if we could get the url for each window on connection)
+				this.context.resetToState({ windows: {} })
+			})
+			.catch((e) => this.context.logger.error('Failed to initialise Sofie Chef connection', e))
 
 		return true
 	}

--- a/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
@@ -93,7 +93,7 @@ export class SofieChefDevice extends Device<SofieChefOptions, SofieChefState, So
 		this._setupWSConnection()
 			.then(() => {
 				// assume empty state on start (would be nice if we could get the url for each window on connection)
-				this.context.resetToState({ windows: {} })
+				this.context.resetToState({ windows: {} }).catch((e) => this.context.logger.error('Failed to reset state', e))
 			})
 			.catch((e) => this.context.logger.error('Failed to initialise Sofie Chef connection', e))
 

--- a/packages/timeline-state-resolver/src/integrations/tcpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/tcpSend/index.ts
@@ -30,6 +30,17 @@ export class TcpSendDevice extends Device<TCPSendOptions, TcpSendDeviceState, Tc
 	private tcpConnection = new TcpConnection()
 
 	async init(options: TCPSendOptions): Promise<boolean> {
+		this.tcpConnection.once('connectionChanged', (connected) => {
+			if (connected) {
+				this.context
+					.resetState()
+					.catch((e) =>
+						this.context.logger.warning(
+							'Failed to reset state after first connection, device may be in unknown state (reason: ' + e + ')'
+						)
+					)
+			}
+		})
 		this.tcpConnection.activate(options)
 		return true
 	}

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/__tests__/vizMSE.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/__tests__/vizMSE.spec.ts
@@ -7,7 +7,6 @@ import {
 	SomeMappingVizMSE,
 	TimelineContentTypeVizMSE,
 	VIZMSETransitionType,
-	VizMSEOptions,
 	VIZMSEPlayoutItemContentExternal,
 	VIZMSEPlayoutItemContentInternal,
 } from 'timeline-state-resolver-types'

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/__tests__/vizMSE.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/__tests__/vizMSE.spec.ts
@@ -1,4 +1,4 @@
-import { Conductor, DeviceOptionsAnyInternal } from '../../../conductor'
+import { Conductor } from '../../../conductor'
 import {
 	Mappings,
 	DeviceType,
@@ -13,7 +13,7 @@ import {
 } from 'timeline-state-resolver-types'
 import { MockTime } from '../../../__tests__/mockTime'
 import { ThreadedClass } from 'threadedclass'
-import { addConnections, awaitNextRemoval, getMockCall, removeConnections } from '../../../__tests__/lib'
+import { addConnections, awaitNextRemoval, getMockCall } from '../../../__tests__/lib'
 import { VizMSEDevice } from '..'
 import * as vConnection from '../../../__mocks__/v-connection'
 import * as net from '../../../__mocks__/net'
@@ -25,7 +25,6 @@ import _ = require('underscore')
 import { StatusCode } from '../../../devices/device'
 import { MOCK_SHOWS } from '../../../__mocks__/v-connection'
 import { literal } from '../../../lib'
-import { ConnectionManager } from '../../../service/ConnectionManager'
 
 const orgSetTimeout = setTimeout
 

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
@@ -144,6 +144,11 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 
 		this._vizmseManager
 			.initializeRundown(activeRundownPlaylistId)
+			.then(() => {
+				// reset any states we had to re-enforce them
+				this.clearStates()
+				this.emit('resyncStates')
+			})
 			.catch((e) => this.emit('error', 'Failed to initialise Viz Rundown', e))
 
 		return true

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
@@ -142,7 +142,9 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 		this._vizmseManager.on('error', (e) => this.emit('error', 'VizMSE', typeof e === 'string' ? new Error(e) : e))
 		this._vizmseManager.on('debug', (...args) => this.emitDebug(...args))
 
-		await this._vizmseManager.initializeRundown(activeRundownPlaylistId)
+		this._vizmseManager
+			.initializeRundown(activeRundownPlaylistId)
+			.catch((e) => this.emit('error', 'Failed to initialise Viz Rundown', e))
 
 		return true
 	}

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
@@ -26,7 +26,6 @@ import {
 import { ThreadedClass } from 'threadedclass'
 import { VMixDevice } from '..'
 import { MockTime } from '../../../__tests__/mockTime'
-import '../../../__tests__/lib'
 import { CommandContext } from '../vMixCommands'
 import { prefixAddedInput } from './mockState'
 import { addConnections } from '../../../__tests__/lib'

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
@@ -29,6 +29,7 @@ import { MockTime } from '../../../__tests__/mockTime'
 import '../../../__tests__/lib'
 import { CommandContext } from '../vMixCommands'
 import { prefixAddedInput } from './mockState'
+import { addConnections } from '../../../__tests__/lib'
 
 const orgSetTimeout = setTimeout
 
@@ -94,19 +95,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -273,19 +276,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -585,19 +590,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -829,19 +836,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -1144,19 +1153,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -1495,19 +1506,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -1722,19 +1735,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -1851,19 +1866,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -1977,19 +1994,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -2103,19 +2122,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -2230,19 +2251,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -2361,19 +2384,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -2493,19 +2518,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -2619,19 +2646,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 8099,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 8099,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -2747,19 +2776,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 9999,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 9999,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -2852,19 +2883,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 9999,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 9999,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -2977,19 +3010,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 9999,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 9999,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -3056,19 +3091,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 9999,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 9999,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -3157,19 +3194,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 9999,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 9999,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -3259,19 +3298,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 9999,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 9999,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -3378,19 +3419,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 9999,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 9999,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)
@@ -3507,19 +3550,21 @@ describe('vMix', () => {
 		await myConductor.init()
 
 		await runPromise(
-			myConductor.addDevice('myvmix', {
-				type: DeviceType.VMIX,
-				options: {
-					host: '127.0.0.1',
-					port: 9999,
-					pollInterval: 0,
+			addConnections(myConductor.connectionManager, {
+				myvmix: {
+					type: DeviceType.VMIX,
+					options: {
+						host: '127.0.0.1',
+						port: 9999,
+						pollInterval: 0,
+					},
+					commandReceiver: commandReceiver0,
 				},
-				commandReceiver: commandReceiver0,
 			}),
 			mockTime
 		)
 
-		const deviceContainer = myConductor.getDevice('myvmix')
+		const deviceContainer = myConductor.connectionManager.getConnection('myvmix')
 		device = deviceContainer!.device as ThreadedClass<VMixDevice>
 		const deviceErrorHandler = jest.fn((...args) => console.log('Error in device', ...args))
 		device.on('error', deviceErrorHandler)

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmix.spec.ts
@@ -224,7 +224,7 @@ describe('vMix', () => {
 		expect(commandReceiver0).toHaveBeenCalledTimes(1)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
 			1,
-			17000,
+			17001,
 			expect.objectContaining({
 				command: {
 					command: VMixCommand.REMOVE_INPUT,
@@ -1079,7 +1079,7 @@ describe('vMix', () => {
 		)
 		expect(commandReceiver0).toHaveBeenNthCalledWith(
 			5,
-			17000,
+			17001,
 			expect.objectContaining({
 				command: {
 					command: VMixCommand.REMOVE_INPUT,

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -161,6 +161,10 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 			if (this._expectingStateAfterConnecting) {
 				this._setFullState(realState)
 				this._expectingStateAfterConnecting = false
+
+				// resync all tl states
+				this.clearStates()
+				this.emit('resyncStates')
 			} else if (this._expectingPolledState) {
 				this._setPartialInputState(realState)
 				this._expectingPolledState = false

--- a/packages/timeline-state-resolver/src/service/ConnectionManager.ts
+++ b/packages/timeline-state-resolver/src/service/ConnectionManager.ts
@@ -1,9 +1,4 @@
-import {
-	DeviceOptionsBase,
-	DeviceOptionsMultiOSC,
-	DeviceOptionsTelemetrics,
-	DeviceType,
-} from 'timeline-state-resolver-types'
+import { DeviceOptionsBase, DeviceType } from 'timeline-state-resolver-types'
 import { BaseRemoteDeviceIntegration, RemoteDeviceInstance } from './remoteDeviceInstance'
 import _ = require('underscore')
 import { ThreadedClassConfig } from 'threadedclass'
@@ -11,13 +6,7 @@ import { DeviceOptionsAnyInternal } from '../conductor'
 import { DeviceContainer } from '..//devices/deviceContainer'
 import { assertNever } from 'atem-connection/dist/lib/atemUtil'
 import { CasparCGDevice, DeviceOptionsCasparCGInternal } from '../integrations/casparCG'
-import { MultiOSCMessageDevice } from '../integrations/multiOsc'
-import { DeviceOptionsPharosInternal, PharosDevice } from '../integrations/pharos'
-import { DeviceOptionsSingularLiveInternal, SingularLiveDevice } from '../integrations/singularLive'
 import { DeviceOptionsSisyfosInternal, SisyfosMessageDevice } from '../integrations/sisyfos'
-import { DeviceOptionsSofieChefInternal, SofieChefDevice } from '../integrations/sofieChef'
-import { TelemetricsDevice } from '../integrations/telemetrics'
-import { DeviceOptionsTriCasterInternal, TriCasterDevice } from '../integrations/tricaster'
 import { DeviceOptionsVizMSEInternal, VizMSEDevice } from '../integrations/vizMSE'
 import { DeviceOptionsVMixInternal, VMixDevice } from '../integrations/vmix'
 import { ImplementedServiceDeviceTypes } from './devices'
@@ -370,15 +359,6 @@ function createContainer(
 				getCurrentTime,
 				threadedClassOptions
 			)
-		case DeviceType.PHAROS:
-			return DeviceContainer.create<DeviceOptionsPharosInternal, typeof PharosDevice>(
-				'../../dist/integrations/pharos/index.js',
-				'PharosDevice',
-				deviceId,
-				deviceOptions,
-				getCurrentTime,
-				threadedClassOptions
-			)
 		case DeviceType.SISYFOS:
 			return DeviceContainer.create<DeviceOptionsSisyfosInternal, typeof SisyfosMessageDevice>(
 				'../../dist/integrations/sisyfos/index.js',
@@ -397,15 +377,6 @@ function createContainer(
 				getCurrentTime,
 				threadedClassOptions
 			)
-		case DeviceType.SINGULAR_LIVE:
-			return DeviceContainer.create<DeviceOptionsSingularLiveInternal, typeof SingularLiveDevice>(
-				'../../dist/integrations/singularLive/index.js',
-				'SingularLiveDevice',
-				deviceId,
-				deviceOptions,
-				getCurrentTime,
-				threadedClassOptions
-			)
 		case DeviceType.VMIX:
 			return DeviceContainer.create<DeviceOptionsVMixInternal, typeof VMixDevice>(
 				'../../dist/integrations/vmix/index.js',
@@ -415,53 +386,23 @@ function createContainer(
 				getCurrentTime,
 				threadedClassOptions
 			)
+		case DeviceType.SINGULAR_LIVE:
 		case DeviceType.TELEMETRICS:
-			return DeviceContainer.create<DeviceOptionsTelemetrics, typeof TelemetricsDevice>(
-				'../../dist/integrations/telemetrics/index.js',
-				'TelemetricsDevice',
-				deviceId,
-				deviceOptions,
-				getCurrentTime,
-				threadedClassOptions
-			)
-		case DeviceType.SOFIE_CHEF:
-			return DeviceContainer.create<DeviceOptionsSofieChefInternal, typeof SofieChefDevice>(
-				'../../dist/integrations/sofieChef/index.js',
-				'SofieChefDevice',
-				deviceId,
-				deviceOptions,
-				getCurrentTime,
-				threadedClassOptions
-			)
-		case DeviceType.TRICASTER:
-			return DeviceContainer.create<DeviceOptionsTriCasterInternal, typeof TriCasterDevice>(
-				'../../dist/integrations/tricaster/index.js',
-				'TriCasterDevice',
-				deviceId,
-				deviceOptions,
-				getCurrentTime,
-				threadedClassOptions
-			)
-		case DeviceType.MULTI_OSC:
-			return DeviceContainer.create<DeviceOptionsMultiOSC, typeof MultiOSCMessageDevice>(
-				'../../dist/integrations/multiOsc/index.js',
-				'MultiOSCMessageDevice',
-				deviceId,
-				deviceOptions,
-				getCurrentTime,
-				threadedClassOptions
-			)
+		case DeviceType.PHAROS:
 		case DeviceType.ABSTRACT:
 		case DeviceType.ATEM:
 		case DeviceType.HTTPSEND:
 		case DeviceType.HTTPWATCHER:
 		case DeviceType.HYPERDECK:
 		case DeviceType.LAWO:
+		case DeviceType.MULTI_OSC:
 		case DeviceType.OBS:
 		case DeviceType.OSC:
 		case DeviceType.PANASONIC_PTZ:
 		case DeviceType.SHOTOKU:
+		case DeviceType.SOFIE_CHEF:
 		case DeviceType.TCPSEND:
+		case DeviceType.TRICASTER:
 		case DeviceType.QUANTEL: {
 			ensureIsImplementedAsService(deviceOptions.type)
 

--- a/packages/timeline-state-resolver/src/service/ConnectionManager.ts
+++ b/packages/timeline-state-resolver/src/service/ConnectionManager.ts
@@ -1,0 +1,395 @@
+import {
+	DeviceOptionsBase,
+	DeviceOptionsMultiOSC,
+	DeviceOptionsTelemetrics,
+	DeviceType,
+} from 'timeline-state-resolver-types'
+import { BaseRemoteDeviceIntegration, RemoteDeviceInstance } from './remoteDeviceInstance'
+import _ = require('underscore')
+import { ThreadedClassConfig } from 'threadedclass'
+import { DeviceOptionsAnyInternal } from '../conductor'
+import { DeviceContainer } from '..//devices/deviceContainer'
+import { assertNever } from 'atem-connection/dist/lib/atemUtil'
+import { CasparCGDevice, DeviceOptionsCasparCGInternal } from '../integrations/casparCG'
+import { MultiOSCMessageDevice } from '../integrations/multiOsc'
+import { DeviceOptionsPharosInternal, PharosDevice } from '../integrations/pharos'
+import { DeviceOptionsSingularLiveInternal, SingularLiveDevice } from '../integrations/singularLive'
+import { DeviceOptionsSisyfosInternal, SisyfosMessageDevice } from '../integrations/sisyfos'
+import { DeviceOptionsSofieChefInternal, SofieChefDevice } from '../integrations/sofieChef'
+import { TelemetricsDevice } from '../integrations/telemetrics'
+import { DeviceOptionsTriCasterInternal, TriCasterDevice } from '../integrations/tricaster'
+import { DeviceOptionsVizMSEInternal, VizMSEDevice } from '../integrations/vizMSE'
+import { DeviceOptionsVMixInternal, VMixDevice } from '../integrations/vmix'
+import { ImplementedServiceDeviceTypes } from './devices'
+import { EventEmitter } from 'eventemitter3'
+import { DeviceEvents } from './device'
+
+interface Operation {
+	operation: 'create' | 'update' | 'delete' | 'setDebug'
+	id: string
+}
+
+const FREEZE_LIMIT = 5000 // how long to wait before considering the child to be unresponsive
+
+export class ConnectionManager extends EventEmitter {
+	private _config: Map<string, DeviceOptionsAnyInternal> = new Map()
+	private _connections: Map<string, BaseRemoteDeviceIntegration<DeviceOptionsAnyInternal>> = new Map()
+	private _updating = false
+
+	/**
+	 * Set the config options for all connections
+	 */
+	public setConnections(connectionsConfig: Map<string, DeviceOptionsAnyInternal>) {
+		this._config = connectionsConfig
+		this._updateConnections()
+	}
+
+	public getConnections(includeUninitialized = false): Array<BaseRemoteDeviceIntegration<DeviceOptionsBase<any>>> {
+		if (includeUninitialized) {
+			return Array.from(this._connections.values())
+		} else {
+			return Array.from(this._connections.values()).filter((conn) => conn.initialized === true)
+		}
+	}
+
+	public getConnection(
+		connectionId: string,
+		includeUninitialized = false
+	): BaseRemoteDeviceIntegration<DeviceOptionsBase<any>> | undefined {
+		if (includeUninitialized) {
+			return this._connections.get(connectionId)
+		} else {
+			const device = this._connections.get(connectionId)
+			if (device?.initialized === true) {
+				return device
+			} else {
+				return undefined
+			}
+		}
+	}
+
+	/**
+	 * Iterate over config and check that the existing device has the right config, if
+	 * not... recreate it
+	 */
+	private _updateConnections() {
+		if (this._updating) return
+		this._updating = true
+
+		const operations: Operation[] = []
+
+		for (const [deviceId, config] of this._config.entries()) {
+			// find connection
+			const connection = this._connections.get(deviceId)
+
+			if (connection) {
+				// see if it should be restarted because of an update
+				if (configHasChanged(connection, config)) {
+					operations.push({ operation: 'update', id: deviceId })
+				} else if (
+					connection.deviceOptions.debug !== config.debug ||
+					connection.deviceOptions.debugState !== config.debugState
+				) {
+					// see if we should set the debug params
+					operations.push({ operation: 'setDebug', id: deviceId })
+				}
+			} else {
+				// create
+				operations.push({ operation: 'create', id: deviceId })
+			}
+		}
+
+		for (const deviceId of this._connections.keys()) {
+			// find if still in config
+			const config = this._config.get(deviceId)
+
+			if (!config) {
+				// not found, so it should be closed
+				operations.push({ operation: 'delete', id: deviceId })
+			}
+		}
+
+		console.log('Ran update, got ops', operations)
+
+		if (operations.length === 0) {
+			// no operations needed
+			this._updating = false
+			return
+		}
+
+		Promise.allSettled(operations.map((op) => this.executeOperation(op))).then(() => {
+			this._updating = false
+			// todo - do another run to verify we have achieved creation of all devices (but prevent us from running into a death loop)
+		})
+	}
+
+	private async executeOperation({ operation, id }: Operation): Promise<void> {
+		// todo: timeout here or log errors?
+
+		switch (operation) {
+			case 'create':
+				await this.createConnection(id)
+				break
+			case 'delete':
+				await this.deleteConnection(id)
+				break
+			case 'update':
+				await this.deleteConnection(id)
+				await this.createConnection(id)
+				break
+			case 'setDebug':
+				await this.setDebugForConnection(id)
+				break
+		}
+	}
+
+	private async createConnection(id: string): Promise<void> {
+		const deviceOptions = this._config.get(id)
+		if (!deviceOptions) return // unexpected - throw error?
+
+		const threadedClassOptions: ThreadedClassConfig = {
+			threadUsage: deviceOptions.threadUsage || 1,
+			autoRestart: false,
+			disableMultithreading: !deviceOptions.isMultiThreaded,
+			instanceName: id,
+			freezeLimit: FREEZE_LIMIT,
+		}
+
+		const container = await createContainer(deviceOptions, id, () => Date.now(), threadedClassOptions) // time out if this gets el stucko
+
+		if (!container) return // todo - log or throw error?
+
+		// set up event handlers
+		this._setupDeviceListeners(id, container)
+
+		this._connections.set(id, container)
+		this.emit('connectionAdded', id, container)
+
+		// trigger device init
+		this._handleConnectionInitialisation(id, container).catch(() => {
+			this.emit('error', 'Device ' + id + ' failed to initialise')
+			this._connections.delete(id) // todo - this will cause device to be recreated next, which may cause a spiral?
+		})
+	}
+
+	private async deleteConnection(id: string): Promise<void> {
+		const connection = this._connections.get(id)
+		if (!connection) return
+
+		this._connections.delete(id)
+		this.emit('connectionRemoved', id)
+
+		try {
+			await connection.device.terminate()
+			await connection.device.removeAllListeners()
+			await connection.terminate()
+		} catch {
+			await connection.terminate()
+		}
+	}
+
+	private async setDebugForConnection(id: string): Promise<void> {
+		const config = this._config.get(id)
+		const connection = this._connections.get(id)
+		if (!connection || !config) return
+
+		try {
+			connection.device.setDebugLogging(config.debug ?? false)
+			connection.device.setDebugState(config.debugState ?? false)
+		} catch {
+			// log warning here
+		}
+	}
+
+	private async _handleConnectionInitialisation(
+		id: string,
+		container: BaseRemoteDeviceIntegration<DeviceOptionsAnyInternal>
+	) {
+		const deviceOptions = this._config.get(id)
+		if (!deviceOptions) return // unexpected - throw error?
+
+		this.emit(
+			'info',
+			`Initializing device ${id} (${container.instanceId}) of type ${DeviceType[deviceOptions.type]}...`
+		)
+		await container.init(deviceOptions.options, undefined)
+		await container.reloadProps()
+		this.emit('info', `Device ${id} (${container.instanceId}) initialized!`)
+	}
+
+	private async _setupDeviceListeners(
+		id: string,
+		container: BaseRemoteDeviceIntegration<DeviceOptionsAnyInternal>
+	): Promise<void> {
+		const passEvent = <T extends keyof DeviceEvents>(ev: T) => {
+			const evHandler: any = (...args: DeviceEvents[T]) => this.emit('connectionEvent:' + ev, id, ...args)
+			container.device.on(ev, evHandler)
+		}
+
+		passEvent('info')
+		passEvent('warning')
+		passEvent('error')
+		passEvent('debug')
+		passEvent('debugState')
+		passEvent('connectionChanged')
+		passEvent('resetResolver')
+		passEvent('slowCommand')
+		passEvent('slowSentCommand')
+		passEvent('slowFulfilledCommand')
+		passEvent('commandReport')
+		passEvent('commandError')
+		passEvent('updateMediaObject')
+		passEvent('clearMediaObjects')
+		passEvent('timeTrace')
+	}
+}
+
+/**
+ * A config has changed if any of the options are no longer the same, taking default values into
+ * consideration. In addition, the debug logging flag should be ignored as that can be changed at runtime.
+ */
+function configHasChanged(
+	connection: BaseRemoteDeviceIntegration<DeviceOptionsBase<any>>,
+	config: DeviceOptionsBase<any>
+): boolean {
+	const oldConfig = connection.deviceOptions
+
+	// first check common options
+	if (
+		oldConfig.disable !== config.disable ||
+		oldConfig.isMultiThreaded !== config.isMultiThreaded ||
+		oldConfig.limitSlowFulfilledCommand !== config.limitSlowFulfilledCommand ||
+		oldConfig.limitSlowSentCommand !== config.limitSlowSentCommand ||
+		oldConfig.reportAllCommands !== config.reportAllCommands ||
+		oldConfig.threadUsage !== config.threadUsage ||
+		oldConfig.type !== config.type
+	)
+		return true
+
+	// now check device specific options
+	return _.isEqual(oldConfig.options, config.options)
+}
+
+function createContainer(
+	deviceOptions: DeviceOptionsAnyInternal,
+	deviceId: string,
+	getCurrentTime: () => number,
+	threadedClassOptions: ThreadedClassConfig
+): Promise<BaseRemoteDeviceIntegration<DeviceOptionsBase<any>>> | null {
+	switch (deviceOptions.type) {
+		case DeviceType.CASPARCG:
+			return DeviceContainer.create<DeviceOptionsCasparCGInternal, typeof CasparCGDevice>(
+				'../../dist/integrations/casparCG/index.js',
+				'CasparCGDevice',
+				deviceId,
+				deviceOptions,
+				getCurrentTime,
+				threadedClassOptions
+			)
+		case DeviceType.PHAROS:
+			return DeviceContainer.create<DeviceOptionsPharosInternal, typeof PharosDevice>(
+				'../../dist/integrations/pharos/index.js',
+				'PharosDevice',
+				deviceId,
+				deviceOptions,
+				getCurrentTime,
+				threadedClassOptions
+			)
+		case DeviceType.SISYFOS:
+			return DeviceContainer.create<DeviceOptionsSisyfosInternal, typeof SisyfosMessageDevice>(
+				'../../dist/integrations/sisyfos/index.js',
+				'SisyfosMessageDevice',
+				deviceId,
+				deviceOptions,
+				getCurrentTime,
+				threadedClassOptions
+			)
+		case DeviceType.VIZMSE:
+			return DeviceContainer.create<DeviceOptionsVizMSEInternal, typeof VizMSEDevice>(
+				'../../dist/integrations/vizMSE/index.js',
+				'VizMSEDevice',
+				deviceId,
+				deviceOptions,
+				getCurrentTime,
+				threadedClassOptions
+			)
+		case DeviceType.SINGULAR_LIVE:
+			return DeviceContainer.create<DeviceOptionsSingularLiveInternal, typeof SingularLiveDevice>(
+				'../../dist/integrations/singularLive/index.js',
+				'SingularLiveDevice',
+				deviceId,
+				deviceOptions,
+				getCurrentTime,
+				threadedClassOptions
+			)
+		case DeviceType.VMIX:
+			return DeviceContainer.create<DeviceOptionsVMixInternal, typeof VMixDevice>(
+				'../../dist/integrations/vmix/index.js',
+				'VMixDevice',
+				deviceId,
+				deviceOptions,
+				getCurrentTime,
+				threadedClassOptions
+			)
+		case DeviceType.TELEMETRICS:
+			return DeviceContainer.create<DeviceOptionsTelemetrics, typeof TelemetricsDevice>(
+				'../../dist/integrations/telemetrics/index.js',
+				'TelemetricsDevice',
+				deviceId,
+				deviceOptions,
+				getCurrentTime,
+				threadedClassOptions
+			)
+		case DeviceType.SOFIE_CHEF:
+			return DeviceContainer.create<DeviceOptionsSofieChefInternal, typeof SofieChefDevice>(
+				'../../dist/integrations/sofieChef/index.js',
+				'SofieChefDevice',
+				deviceId,
+				deviceOptions,
+				getCurrentTime,
+				threadedClassOptions
+			)
+		case DeviceType.TRICASTER:
+			return DeviceContainer.create<DeviceOptionsTriCasterInternal, typeof TriCasterDevice>(
+				'../../dist/integrations/tricaster/index.js',
+				'TriCasterDevice',
+				deviceId,
+				deviceOptions,
+				getCurrentTime,
+				threadedClassOptions
+			)
+		case DeviceType.MULTI_OSC:
+			return DeviceContainer.create<DeviceOptionsMultiOSC, typeof MultiOSCMessageDevice>(
+				'../../dist/integrations/multiOsc/index.js',
+				'MultiOSCMessageDevice',
+				deviceId,
+				deviceOptions,
+				getCurrentTime,
+				threadedClassOptions
+			)
+		case DeviceType.ABSTRACT:
+		case DeviceType.ATEM:
+		case DeviceType.HTTPSEND:
+		case DeviceType.HTTPWATCHER:
+		case DeviceType.HYPERDECK:
+		case DeviceType.LAWO:
+		case DeviceType.OBS:
+		case DeviceType.OSC:
+		case DeviceType.PANASONIC_PTZ:
+		case DeviceType.SHOTOKU:
+		case DeviceType.TCPSEND:
+		case DeviceType.QUANTEL: {
+			ensureIsImplementedAsService(deviceOptions.type)
+
+			// presumably this device is implemented in the new service handler
+			return RemoteDeviceInstance.create(deviceId, deviceOptions, getCurrentTime, threadedClassOptions)
+		}
+		default:
+			assertNever(deviceOptions)
+			return null
+	}
+}
+
+function ensureIsImplementedAsService(_type: ImplementedServiceDeviceTypes): void {
+	// This is a type check
+}

--- a/packages/timeline-state-resolver/src/service/ConnectionManager.ts
+++ b/packages/timeline-state-resolver/src/service/ConnectionManager.ts
@@ -42,7 +42,7 @@ export interface ConnectionManagerIntEvents {
 	connectionRemoved: [id: string]
 }
 export type MappedDeviceEvents = {
-	[T in keyof DeviceInstanceEvents as `connectionEvent:${T}`]: [deviceId: string, ...DeviceInstanceEvents[T]]
+	[T in keyof DeviceInstanceEvents as `connectionEvent:${T}`]: [string, ...DeviceInstanceEvents[T]]
 }
 
 export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {

--- a/packages/timeline-state-resolver/src/service/ConnectionManager.ts
+++ b/packages/timeline-state-resolver/src/service/ConnectionManager.ts
@@ -149,7 +149,10 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 			this._updating = false
 
 			// wait until next
-			const nextTime = Array.from(this._connectionAttempts.values()).reduce((a, b) => (a.next < b.next ? a : b))
+			const nextTime = Array.from(this._connectionAttempts.values()).reduce((a, b) => (a.next < b.next ? a : b), {
+				last: Date.now(), // not used
+				next: Date.now() + 4000, // in 4 seconds
+			})
 			this._nextAttempt = setTimeout(() => {
 				this._updateConnections()
 			}, nextTime.next - Date.now())

--- a/packages/timeline-state-resolver/src/service/ConnectionManager.ts
+++ b/packages/timeline-state-resolver/src/service/ConnectionManager.ts
@@ -267,7 +267,7 @@ function configHasChanged(
 		return true
 
 	// now check device specific options
-	return _.isEqual(oldConfig.options, config.options)
+	return !_.isEqual(oldConfig.options, config.options)
 }
 
 function createContainer(

--- a/packages/timeline-state-resolver/src/service/ConnectionManager.ts
+++ b/packages/timeline-state-resolver/src/service/ConnectionManager.ts
@@ -47,17 +47,17 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 	/**
 	 * Set the config options for all connections
 	 */
-	public setConnections(connectionsConfig: Map<string, DeviceOptionsAnyInternal>) {
+	public setConnections(connectionsConfig: Record<string, DeviceOptionsAnyInternal>) {
 		// run through and see if we need to reset any of the counters
 		this._config.forEach((conf, id) => {
-			const newConf = connectionsConfig.get(id)
+			const newConf = connectionsConfig[id]
 			if (newConf && configHasChanged(conf, newConf)) {
 				// new conf warrants an immediate retry
 				this._connectionAttempts.delete(id)
 			}
 		})
 
-		this._config = connectionsConfig
+		this._config = new Map(Object.entries<DeviceOptionsAnyInternal>(connectionsConfig))
 		this._updateConnections()
 	}
 

--- a/packages/timeline-state-resolver/src/service/ConnectionManager.ts
+++ b/packages/timeline-state-resolver/src/service/ConnectionManager.ts
@@ -29,6 +29,7 @@ export interface ConnectionManagerIntEvents {
 	debug: [...debug: any[]]
 
 	connectionAdded: [id: string, container: BaseRemoteDeviceIntegration<DeviceOptionsBase<any>>]
+	connectionInitialised: [id: string]
 	connectionRemoved: [id: string]
 }
 export type MappedDeviceEvents = {
@@ -218,6 +219,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 		this._handleConnectionInitialisation(id, container)
 			.then(() => {
 				this._connectionAttempts.delete(id)
+				this.emit('connectionInitialised', id)
 			})
 			.catch((e) => {
 				this.emit('error', 'Connection ' + id + ' failed to initialise')

--- a/packages/timeline-state-resolver/src/service/DeviceInstance.ts
+++ b/packages/timeline-state-resolver/src/service/DeviceInstance.ts
@@ -264,13 +264,13 @@ export class DeviceInstanceWrapper extends EventEmitter<DeviceInstanceEvents> {
 			resetState: async () => {
 				await this._stateHandler.setCurrentState(undefined)
 				await this._stateHandler.clearFutureStates()
-				this.emit('resetResolver')
+				this.emit('resyncStates')
 			},
 
 			resetToState: async (state: any) => {
 				await this._stateHandler.setCurrentState(state)
 				await this._stateHandler.clearFutureStates()
-				this.emit('resetResolver')
+				this.emit('resyncStates')
 			},
 		}
 	}

--- a/packages/timeline-state-resolver/src/service/__tests__/ConnectionManager.spec.ts
+++ b/packages/timeline-state-resolver/src/service/__tests__/ConnectionManager.spec.ts
@@ -1,7 +1,6 @@
 import { DeviceType, OSCDeviceType } from 'timeline-state-resolver-types'
 import { ConstructedMockDevices, MockDeviceInstanceWrapper } from '../../__tests__/mockDeviceInstanceWrapper'
 import { ConnectionManager } from '../ConnectionManager'
-import { DeviceOptionsAnyInternal } from '../..'
 
 // Mock explicitly the 'dist' version, as that is what threadedClass is being told to load
 jest.mock('../../../dist/service/DeviceInstance', () => ({
@@ -27,26 +26,22 @@ describe('ConnectionManager', () => {
 			if (resolveRemoved) resolveRemoved()
 		})
 
-		connManager.setConnections(
-			new Map(
-				Object.entries<DeviceOptionsAnyInternal>({
-					osc0: {
-						type: DeviceType.OSC,
-						options: {
-							host: '127.0.0.1',
-							port: 5250,
-							type: OSCDeviceType.UDP,
-						},
-					},
-				})
-			)
-		)
+		connManager.setConnections({
+			osc0: {
+				type: DeviceType.OSC,
+				options: {
+					host: '127.0.0.1',
+					port: 5250,
+					type: OSCDeviceType.UDP,
+				},
+			},
+		})
 
 		await psAdded
 
 		expect(ConstructedMockDevices['osc0']).toBeTruthy()
 
-		connManager.setConnections(new Map())
+		connManager.setConnections({})
 
 		await psRemoved
 

--- a/packages/timeline-state-resolver/src/service/__tests__/ConnectionManager.spec.ts
+++ b/packages/timeline-state-resolver/src/service/__tests__/ConnectionManager.spec.ts
@@ -1,0 +1,54 @@
+import { DeviceType, OSCDeviceType } from 'timeline-state-resolver-types'
+import { ConstructedMockDevices, MockDeviceInstanceWrapper } from '../../__tests__/mockDeviceInstanceWrapper'
+import { ConnectionManager } from '../ConnectionManager'
+
+// Mock explicitly the 'dist' version, as that is what threadedClass is being told to load
+jest.mock('../../../dist/service/DeviceInstance', () => ({
+	DeviceInstanceWrapper: MockDeviceInstanceWrapper,
+}))
+jest.mock('../DeviceInstance', () => ({
+	DeviceInstanceWrapper: MockDeviceInstanceWrapper,
+}))
+
+describe('ConnectionManager', () => {
+	const connManager = new ConnectionManager()
+
+	test('adding/removing a device', async () => {
+		let resolveAdded: undefined | (() => void) = undefined
+		const psAdded = new Promise<void>((resolveCb) => (resolveAdded = resolveCb))
+		connManager.on('connectionAdded', () => {
+			if (resolveAdded) resolveAdded()
+		})
+
+		let resolveRemoved: undefined | (() => void) = undefined
+		const psRemoved = new Promise<void>((resolveCb) => (resolveRemoved = resolveCb))
+		connManager.on('connectionRemoved', () => {
+			if (resolveRemoved) resolveRemoved()
+		})
+
+		connManager.setConnections(
+			new Map(
+				Object.entries({
+					osc0: {
+						type: DeviceType.OSC,
+						options: {
+							host: '127.0.0.1',
+							port: 5250,
+							type: OSCDeviceType.UDP,
+						},
+					},
+				})
+			)
+		)
+
+		await psAdded
+
+		expect(ConstructedMockDevices['osc0']).toBeTruthy()
+
+		connManager.setConnections(new Map())
+
+		await psRemoved
+
+		expect(ConstructedMockDevices['osc0']).toBeFalsy()
+	})
+})

--- a/packages/timeline-state-resolver/src/service/__tests__/ConnectionManager.spec.ts
+++ b/packages/timeline-state-resolver/src/service/__tests__/ConnectionManager.spec.ts
@@ -1,6 +1,7 @@
 import { DeviceType, OSCDeviceType } from 'timeline-state-resolver-types'
 import { ConstructedMockDevices, MockDeviceInstanceWrapper } from '../../__tests__/mockDeviceInstanceWrapper'
 import { ConnectionManager } from '../ConnectionManager'
+import { DeviceOptionsAnyInternal } from '../..'
 
 // Mock explicitly the 'dist' version, as that is what threadedClass is being told to load
 jest.mock('../../../dist/service/DeviceInstance', () => ({
@@ -28,7 +29,7 @@ describe('ConnectionManager', () => {
 
 		connManager.setConnections(
 			new Map(
-				Object.entries({
+				Object.entries<DeviceOptionsAnyInternal>({
 					osc0: {
 						type: DeviceType.OSC,
 						options: {

--- a/packages/timeline-state-resolver/src/service/device.ts
+++ b/packages/timeline-state-resolver/src/service/device.ts
@@ -111,6 +111,8 @@ export interface DeviceEvents {
 	connectionChanged: [status: Omit<DeviceStatus, 'active'>]
 	/** A message to the resolver that something has happened that warrants a reset of the resolver (to re-run it again) */
 	resetResolver: []
+	/** A message to the resolver that the device needs to receive all known states */
+	resyncStates: []
 
 	/** @deprecated replaced by slowSentCommand & slowFulfilledCommand  */
 	slowCommand: [commandInfo: string]


### PR DESCRIPTION
## Type of Contribution

This is a  Code improvement


## Current Behavior
Library consumers must keep track of how devices are created and initialised and are responsible for managing this. In addition, a device may not finish initialising until the first connection has been made.


## Proposed Behavior
A Connection is an instance of an Integration Implementation (previously known as devices, this terminology proved to be a bit confusing as "TSR devices" connected to actual devices). TSR shall be responsible for creating and initialising the connections based upon a config provided by the library user. An integration must ensure to not get stuck during the initialisation.


## Discussion
~~I think there may actually some use for devices not being initialised immediately as it prevents the timeline states from being sent into the integration when it isn't ready yet. At the same time, integrations should handle this "disconnected" state gracefully. Perhaps some additional life cycle hooks are required (i.e. to rediff the state from empty)~~


## Status
This PR is part investigation and part implementation. Feedback is welcome at this time.
