### PR TITLE
feat(HTTPSend): return response data from HTTP SendCommand action

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/httpSend.ts
+++ b/packages/timeline-state-resolver-types/src/generated/httpSend.ts
@@ -61,13 +61,21 @@ export enum TimelineContentTypeHTTPParamType {
 	FORM = 'form'
 }
 
+export interface SendCommandResult {
+	statusCode: number
+	headers: {
+		[k: string]: string | string[]
+	}
+	body: string
+}
+
 export enum HttpSendActions {
 	Resync = 'resync',
 	SendCommand = 'sendCommand'
 }
 export interface HttpSendActionExecutionResults {
 	resync: () => void,
-	sendCommand: (payload: HTTPSendCommandContent) => void
+	sendCommand: (payload: HTTPSendCommandContent) => SendCommandResult
 }
 export type HttpSendActionExecutionPayload<A extends keyof HttpSendActionExecutionResults> = Parameters<
 	HttpSendActionExecutionResults[A]

--- a/packages/timeline-state-resolver/src/integrations/httpSend/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/$schemas/actions.json
@@ -60,6 +60,35 @@
 				},
 				"required": ["type", "url", "params"],
 				"additionalProperties": false
+			},
+			"result": {
+				"type": "object",
+				"properties": {
+					"statusCode":  {
+						"type": "number"
+					},
+					"headers": {
+						"type": "object",
+						"additionalProperties": {
+							"oneOf": [
+								{ "type": "string" },
+								{
+								  "type": "array",
+								  "items": { "type": "string" }
+								}
+							]
+						}
+					},
+					"body": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"statusCode",
+					"headers",
+					"body"
+				],
+				"additionalProperties": false
 			}
 		}
 	]

--- a/packages/timeline-state-resolver/src/integrations/httpSend/AuthenticatedHTTPSendDevice.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/AuthenticatedHTTPSendDevice.ts
@@ -1,4 +1,4 @@
-import { HTTPSendOptions } from 'timeline-state-resolver-types'
+import { ActionExecutionResult, HTTPSendOptions, SendCommandResult } from 'timeline-state-resolver-types'
 import { HTTPSendDevice, HttpSendDeviceCommand } from '.'
 import { AccessToken, ClientCredentials } from 'simple-oauth2'
 
@@ -114,7 +114,11 @@ export class AuthenticatedHTTPSendDevice extends HTTPSendDevice {
 		return token
 	}
 
-	async sendCommand({ timelineObjId, context, command }: HttpSendDeviceCommand): Promise<void> {
+	async sendCommandWithResult({
+		timelineObjId,
+		context,
+		command,
+	}: HttpSendDeviceCommand): Promise<ActionExecutionResult<SendCommandResult>> {
 		if (this.authOptions) {
 			const bearerToken =
 				this.authOptions.method === AuthMethod.BEARER_TOKEN ? this.authOptions.bearerToken : await this.tokenPromise
@@ -129,6 +133,6 @@ export class AuthenticatedHTTPSendDevice extends HTTPSendDevice {
 				}
 			}
 		}
-		return super.sendCommand({ timelineObjId, context, command })
+		return super.sendCommandWithResult({ timelineObjId, context, command })
 	}
 }

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -63,7 +63,7 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 			this.executeSendCommandAction(payload as HTTPSendCommandContent | undefined),
 	}
 
-	async executeResyncAction(): Promise<ActionExecutionResult<undefined>> {
+	private async executeResyncAction(): Promise<ActionExecutionResult<undefined>> {
 		this.context.resetResolver()
 		return { result: ActionExecutionResultCode.Ok }
 	}

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -6,6 +6,7 @@ import {
 	HTTPSendCommandContent,
 	HTTPSendOptions,
 	HttpSendActions,
+	SendCommandResult,
 	StatusCode,
 	TSRTimelineContent,
 	Timeline,
@@ -54,19 +55,22 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 			messages: [],
 		}
 	}
-
 	readonly actions: {
-		[id in HttpSendActions]: (id: string, payload?: Record<string, any>) => Promise<ActionExecutionResult>
+		[id in HttpSendActions]: (id: string, payload?: Record<string, any>) => Promise<ActionExecutionResult<any>>
 	} = {
-		[HttpSendActions.Resync]: async () => {
-			this.context.resetResolver()
-			return { result: ActionExecutionResultCode.Ok }
-		},
+		[HttpSendActions.Resync]: async (_id) => this.executeResyncAction(),
 		[HttpSendActions.SendCommand]: async (_id: string, payload?: Record<string, any>) =>
-			this.sendManualCommand(payload as HTTPSendCommandContent | undefined),
+			this.executeSendCommandAction(payload as HTTPSendCommandContent | undefined),
 	}
 
-	private async sendManualCommand(cmd?: HTTPSendCommandContent): Promise<ActionExecutionResult> {
+	async executeResyncAction(): Promise<ActionExecutionResult<undefined>> {
+		this.context.resetResolver()
+		return { result: ActionExecutionResultCode.Ok }
+	}
+
+	private async executeSendCommandAction(
+		cmd?: HTTPSendCommandContent
+	): Promise<ActionExecutionResult<SendCommandResult>> {
 		if (!cmd)
 			return {
 				result: ActionExecutionResultCode.Error,
@@ -97,7 +101,7 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 			}
 		}
 
-		await this.sendCommand({
+		const response = await this.sendCommandWithResult({
 			timelineObjId: '',
 			context: 'makeReady',
 			command: {
@@ -107,9 +111,11 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 			},
 		}).catch(() => this.context.logger.warning('Manual command failed: ' + JSON.stringify(cmd)))
 
-		return {
-			result: ActionExecutionResultCode.Ok,
-		}
+		return (
+			response ?? {
+				result: ActionExecutionResultCode.Error,
+			}
+		)
 	}
 
 	convertTimelineStateToDeviceState(state: Timeline.TimelineState<TSRTimelineContent>): HttpSendDeviceState {
@@ -168,6 +174,13 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 		return commands
 	}
 	async sendCommand({ timelineObjId, context, command }: HttpSendDeviceCommand): Promise<void> {
+		await this.sendCommandWithResult({ timelineObjId, context, command })
+	}
+	async sendCommandWithResult({
+		timelineObjId,
+		context,
+		command,
+	}: HttpSendDeviceCommand): Promise<ActionExecutionResult<SendCommandResult>> {
 		const commandHash = this.getTrackedStateHash(command)
 
 		if (command.commandName === 'added' || command.commandName === 'changed') {
@@ -179,10 +192,15 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 		// Avoid sending multiple identical commands for the same state:
 		if (command.layer && command.commandName !== 'manual') {
 			const trackedHash = this.trackedState.get(command.layer)
-			if (commandHash !== trackedHash) return Promise.resolve() // command is no longer relevant to state
+			if (commandHash !== trackedHash)
+				return {
+					result: ActionExecutionResultCode.Error,
+				} // command is no longer relevant to state
 		}
 		if (this._terminated) {
-			return Promise.resolve()
+			return {
+				result: ActionExecutionResultCode.Error,
+			}
 		}
 
 		const cwc: CommandWithContext = {
@@ -245,6 +263,15 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 					`HTTPSend: ${command.content.type}: Bad statuscode response on url "${command.content.url}": ${response.statusCode} (${context})`
 				)
 			}
+
+			return {
+				result: ActionExecutionResultCode.Ok,
+				resultData: {
+					body: response.body,
+					statusCode: response.statusCode,
+					headers: response.headers as Record<string, string | string[]>,
+				},
+			}
 		} catch (error) {
 			const err = error as RequestError // make typescript happy
 
@@ -280,6 +307,10 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 						}).catch(() => null) // errors will be emitted
 					}, timeLeft)
 				}
+			}
+
+			return {
+				result: ActionExecutionResultCode.Error,
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This PR is opened on behalf of TV 2 Norge.

## Type of Contribution

This is a: 
<!-- (pick one) -->
Feature


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
SendCommand action of the HTTPSend device exists but does not provide any information about the received response.

## New Behavior
<!--
What is the new behavior?
-->
If the request succeeds, SendCommand action provides a result including `statusCode`, `headers` and `body` of the response.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
