### PR TITLE
fix: sisyfos add fade time during reset

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -138,13 +138,13 @@ export class SisyfosApi extends EventEmitter {
 				const args: Array<MetaArgument> = [
 					{
 						type: 'i',
-						value: command.values.pgmOn as number,
+						value: command.values.pgmOn,
 					},
 				]
 				if (command.values.fadeTime) {
 					args.push({
 						type: 'f',
-						value: command.values.fadeTime as number,
+						value: command.values.fadeTime,
 					})
 				}
 				this._oscClient.send({

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -135,14 +135,21 @@ export class SisyfosApi extends EventEmitter {
 				})
 			}
 			if (command.values.pgmOn !== undefined) {
+				const args: Array<MetaArgument> = [
+					{
+						type: 'i',
+						value: command.values.pgmOn as number,
+					},
+				]
+				if (command.values.fadeTime) {
+					args.push({
+						type: 'f',
+						value: command.values.fadeTime as number,
+					})
+				}
 				this._oscClient.send({
 					address: `/ch/${command.channel + 1}/pgm`,
-					args: [
-						{
-							type: 'i',
-							value: command.values.pgmOn,
-						},
-					],
+					args,
 				})
 			}
 			if (command.values.pstOn !== undefined) {


### PR DESCRIPTION
## Type of Contribution

This is a: **Bug fix** 


## Current Behavior
TSR will not send the fadeTime parameter for PGM changes when the change comes from a `triggerValue` change


## New Behavior
TSR send the fadeTime paramter for PGM changes during a channel reset



