### PR TITLE
fix: viz and quantel callback leak

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/vizMSE/vizMSEManager.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/vizMSEManager.ts
@@ -1239,8 +1239,9 @@ export class VizMSEManager extends EventEmitter {
 		this.emit('connectionChanged', this._mseConnected && this._msePingConnected)
 	}
 
-	public clearAllWaitWithLayer(portId: string) {
-		this._waitWithLayers.clearAllForKey(portId)
+	public clearAllWaitWithLayer(_portId: string) {
+		// HACK: Prior to #344 this was broken. This has been left in the broken state until it can be tested that the 'fix' doesn't cause other issues SOFIE-3419
+		// this._waitWithLayers.clearAllForKey(portId)
 	}
 	/**
 	 * Returns true if the wait was cleared from someone else

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/vizMSEManager.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/vizMSEManager.ts
@@ -41,6 +41,7 @@ import {
 import { VizEngineTcpSender } from './vizEngineTcpSender'
 import * as crypto from 'crypto'
 import * as path from 'path'
+import { WaitGroup } from '../../waitGroup'
 
 /** Minimum time to wait before removing an element after an expectedPlayoutItem has been removed */
 const DELETE_TIME_WAIT = 20 * 1000
@@ -82,9 +83,7 @@ export class VizMSEManager extends EventEmitter {
 	private _mseConnected: boolean | undefined = undefined // undefined: first connection not established yet
 	private _msePingConnected = false
 	private _loadingAllElements = false
-	private _waitWithLayers: {
-		[portId: string]: Function[]
-	} = {}
+	private _waitWithLayers = new WaitGroup()
 	public ignoreAllWaits = false // Only to be used in tests
 	private _terminated = false
 	private _activeRundownPlaylistId: string | undefined
@@ -1241,23 +1240,13 @@ export class VizMSEManager extends EventEmitter {
 	}
 
 	public clearAllWaitWithLayer(portId: string) {
-		if (!this._waitWithLayers[portId]) {
-			_.each(this._waitWithLayers[portId], (fcn) => {
-				fcn(true)
-			})
-		}
+		this._waitWithLayers.clearAllForKey(portId)
 	}
 	/**
 	 * Returns true if the wait was cleared from someone else
 	 */
 	private async waitWithLayer(layerId: string, delay: number): Promise<boolean> {
-		return new Promise((resolve) => {
-			if (!this._waitWithLayers[layerId]) this._waitWithLayers[layerId] = []
-			this._waitWithLayers[layerId].push(resolve)
-			setTimeout(() => {
-				resolve(false)
-			}, delay || 0)
-		})
+		return this._waitWithLayers.waitOnKey(layerId, delay)
 	}
 	private getElementsToKeep(): VIZMSEPlayoutItemContentExternal[] {
 		return this._expectedPlayoutItems

--- a/packages/timeline-state-resolver/src/waitGroup.ts
+++ b/packages/timeline-state-resolver/src/waitGroup.ts
@@ -1,9 +1,15 @@
 type ResolveFn = (value: boolean) => void
 
+/**
+ * A WaitGroup is used to wait for a number of operations to complete, or timeout
+ */
 export class WaitGroup {
 	#store: Map<string, Map<number, ResolveFn>> = new Map()
 	#nextId = 0
 
+	/**
+	 * Resolve all waiting operations for a key, with success
+	 */
 	clearAllForKey(key: string): void {
 		const callbacks = this.#store.get(key)
 		if (!callbacks) return
@@ -15,11 +21,14 @@ export class WaitGroup {
 		}
 	}
 
-	async waitOnKey(portId: string, delay: number): Promise<boolean> {
-		let callbacks = this.#store.get(portId)
+	/**
+	 * Wait for a key to be resolved (true), or timeout (false)
+	 */
+	async waitOnKey(key: string, delay: number): Promise<boolean> {
+		let callbacks = this.#store.get(key)
 		if (!callbacks) {
 			callbacks = new Map()
-			this.#store.set(portId, callbacks)
+			this.#store.set(key, callbacks)
 		}
 		const callbacks2 = callbacks
 

--- a/packages/timeline-state-resolver/src/waitGroup.ts
+++ b/packages/timeline-state-resolver/src/waitGroup.ts
@@ -1,0 +1,39 @@
+type ResolveFn = (value: boolean) => void
+
+export class WaitGroup {
+	#store: Map<string, Map<number, ResolveFn>> = new Map()
+	#nextId = 0
+
+	clearAllForKey(key: string): void {
+		const callbacks = this.#store.get(key)
+		if (!callbacks) return
+
+		this.#store.delete(key)
+
+		for (const resolve of callbacks.values()) {
+			resolve(true)
+		}
+	}
+
+	async waitOnKey(portId: string, delay: number): Promise<boolean> {
+		let callbacks = this.#store.get(portId)
+		if (!callbacks) {
+			callbacks = new Map()
+			this.#store.set(portId, callbacks)
+		}
+		const callbacks2 = callbacks
+
+		const id = this.#nextId++
+
+		return new Promise((resolve) => {
+			const callbackWithCleanup = (value: boolean) => {
+				callbacks2.delete(id)
+
+				resolve(value)
+			}
+
+			callbacks2.set(id, callbackWithCleanup)
+			setTimeout(() => callbackWithCleanup(false), delay || 0)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of the NRK.



## Type of Contribution

This is a: Bug fix 


## Current Behavior
viz and quantel use a similar flow of waiting and being able to satisfy those waits.
queued callbacks were never being cleared once called, resulting in them being gradually leaked

## New Behavior

this has been refactored to share a common implementation, with the new implementation cleaning up the callbacks as they are called.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
