### PR TITLE
Filter mappings such that an integration only sees its own mappings

### DIFF
--- a/packages/timeline-state-resolver/src/__tests__/conductor.spec.ts
+++ b/packages/timeline-state-resolver/src/__tests__/conductor.spec.ts
@@ -145,14 +145,14 @@ describe('Conductor', () => {
 					},
 					time: 10005,
 				}),
-				device0Mappings // TODO - is this correct?
+				device0Mappings
 			)
 			expect(device0.handleState).toHaveBeenNthCalledWith(
 				2,
 				expect.objectContaining({
 					time: 11000,
 				}),
-				device0Mappings // TODO - is this correct?
+				device0Mappings
 			)
 			expect(device0.handleState).toHaveBeenNthCalledWith(
 				3,
@@ -160,7 +160,7 @@ describe('Conductor', () => {
 					layers: {},
 					time: 12000,
 				}),
-				device0Mappings // TODO - is this correct?
+				device0Mappings
 			)
 
 			// Ensure device1 has been fed sensible states
@@ -171,7 +171,7 @@ describe('Conductor', () => {
 				expect.objectContaining({
 					layers: {},
 				}),
-				device1Mappings // TODO - is this correct?
+				device1Mappings
 			)
 			expect(device1.handleState).toHaveBeenNthCalledWith(
 				2,
@@ -186,14 +186,14 @@ describe('Conductor', () => {
 						}),
 					},
 				}),
-				device1Mappings // TODO - is this correct?
+				device1Mappings
 			)
 			expect(device1.handleState).toHaveBeenNthCalledWith(
 				3,
 				expect.objectContaining({
 					layers: {},
 				}),
-				device1Mappings // TODO - is this correct?
+				device1Mappings
 			)
 
 			// Remove the device

--- a/packages/timeline-state-resolver/src/__tests__/conductor.spec.ts
+++ b/packages/timeline-state-resolver/src/__tests__/conductor.spec.ts
@@ -58,9 +58,15 @@ describe('Conductor', () => {
 			deviceId: 'device1',
 			options: {},
 		}
-		const myLayerMapping: Mappings = {
+		const device0Mappings: Mappings = {
 			myLayer0: myLayerMapping0,
+		}
+		const device1Mappings: Mappings = {
 			myLayer1: myLayerMapping1,
+		}
+		const myLayerMapping: Mappings = {
+			...device0Mappings,
+			...device1Mappings,
 		}
 
 		const conductor = new Conductor({
@@ -139,14 +145,14 @@ describe('Conductor', () => {
 					},
 					time: 10005,
 				}),
-				myLayerMapping // TODO - is this correct?
+				device0Mappings // TODO - is this correct?
 			)
 			expect(device0.handleState).toHaveBeenNthCalledWith(
 				2,
 				expect.objectContaining({
 					time: 11000,
 				}),
-				myLayerMapping // TODO - is this correct?
+				device0Mappings // TODO - is this correct?
 			)
 			expect(device0.handleState).toHaveBeenNthCalledWith(
 				3,
@@ -154,7 +160,7 @@ describe('Conductor', () => {
 					layers: {},
 					time: 12000,
 				}),
-				myLayerMapping // TODO - is this correct?
+				device0Mappings // TODO - is this correct?
 			)
 
 			// Ensure device1 has been fed sensible states
@@ -165,7 +171,7 @@ describe('Conductor', () => {
 				expect.objectContaining({
 					layers: {},
 				}),
-				myLayerMapping // TODO - is this correct?
+				device1Mappings // TODO - is this correct?
 			)
 			expect(device1.handleState).toHaveBeenNthCalledWith(
 				2,
@@ -180,14 +186,14 @@ describe('Conductor', () => {
 						}),
 					},
 				}),
-				myLayerMapping // TODO - is this correct?
+				device1Mappings // TODO - is this correct?
 			)
 			expect(device1.handleState).toHaveBeenNthCalledWith(
 				3,
 				expect.objectContaining({
 					layers: {},
 				}),
-				myLayerMapping // TODO - is this correct?
+				device1Mappings // TODO - is this correct?
 			)
 
 			// Remove the device

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -1087,8 +1087,13 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 		deviceId: string,
 		time: number,
 		state: Timeline.TimelineState<TSRTimelineContent>,
-		mappings: Mappings
+		unfilteredMappings: Mappings
 	) {
+		// only take mappings that are for this deviceId
+		const mappings = Object.fromEntries(
+			Object.entries<Mapping<unknown>>(unfilteredMappings).filter(([_, mapping]) => mapping.deviceId === deviceId)
+		)
+
 		if (!this._deviceStates[deviceId]) this._deviceStates[deviceId] = []
 
 		// find all references to the datastore that are in this state

--- a/packages/timeline-state-resolver/src/service/devices.ts
+++ b/packages/timeline-state-resolver/src/service/devices.ts
@@ -146,6 +146,6 @@ export const DevicesDict: Record<ImplementedServiceDeviceTypes, DeviceEntry> = {
 		deviceClass: QuantelDevice,
 		canConnect: true,
 		deviceName: (deviceId: string) => 'Quantel' + deviceId,
-		executionMode: () => 'salvo',
+		executionMode: () => 'sequential',
 	},
 }


### PR DESCRIPTION
## Current Behavior
An integration is given access to all the mappings and has to manually filter for device type and device id. This means that unless the developer filters for the device id, the mappings may be targeted at a different device.


## New Behavior
Mappings are filtered for the device id before passing them to the integration.



## Other Information
Perhaps in the future we should also try to filter out mappings that have the wrong type

## Status
~~This is awaiting some testing in a production environment~~ This has been tested in a production environment
