### PR TITLE
fix(HTTPSend): Allow HTTPSend commands to be sent in separate sequential queues (SOFIE-3431)

### DIFF
--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -170,5 +170,6 @@ export interface ActionExecutionResult<ResultData = undefined> {
 
 export enum ActionExecutionResultCode {
 	Error = 'ERROR',
+	IgnoredNotRelevant = 'IGNORED',
 	Ok = 'OK',
 }

--- a/packages/timeline-state-resolver/src/integrations/httpSend/__tests__/httpsend.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/__tests__/httpsend.spec.ts
@@ -346,6 +346,7 @@ describe('HTTP-Send', () => {
 							content: content,
 							layer: 'layer0',
 						},
+						queueId: undefined,
 					},
 				])
 				await Promise.all(commands.map(async (c) => device.sendCommand(c)))
@@ -362,6 +363,7 @@ describe('HTTP-Send', () => {
 							content: content,
 							layer: 'layer0',
 						},
+						queueId: undefined,
 					},
 				])
 			}

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -136,6 +136,7 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 						content: newLayer.content as HTTPSendCommandContent,
 						layer: layerKey,
 					},
+					queueId: (newLayer.content as HTTPSendCommandContent)?.queueId,
 				})
 			} else {
 				// changed?
@@ -149,6 +150,7 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 							content: newLayer.content as HTTPSendCommandContent,
 							layer: layerKey,
 						},
+						queueId: (newLayer.content as HTTPSendCommandContent)?.queueId,
 					})
 				}
 			}
@@ -162,6 +164,7 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 					timelineObjId: oldLayer.id,
 					context: `removed: ${oldLayer.id}`,
 					command: { commandName: 'removed', content: oldLayer.content as HTTPSendCommandContent, layer: layerKey },
+					queueId: (oldLayer.content as HTTPSendCommandContent)?.queueId,
 				})
 			}
 		})
@@ -194,7 +197,7 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 			const trackedHash = this.trackedState.get(command.layer)
 			if (commandHash !== trackedHash)
 				return {
-					result: ActionExecutionResultCode.Error,
+					result: ActionExecutionResultCode.IgnoredNotRelevant,
 				} // command is no longer relevant to state
 		}
 		if (this._terminated) {
@@ -254,7 +257,7 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 
 			const response = await httpReq(command.content.url, options)
 
-			if (response.statusCode === 200) {
+			if (response.statusCode >= 200 && response.statusCode < 300) {
 				this.context.logger.debug(
 					`HTTPSend: ${command.content.type}: Good statuscode response on url "${command.content.url}": ${response.statusCode} (${context})`
 				)

--- a/packages/timeline-state-resolver/src/integrations/quantel/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/connection.ts
@@ -591,11 +591,10 @@ export class QuantelManager extends EventEmitter {
 		})
 	}
 	public clearAllWaitWithPort(portId: string) {
-		if (!this._waitWithPorts[portId]) {
-			_.each(this._waitWithPorts[portId], (fcn) => {
-				fcn(true)
-			})
-		}
+		if (!this._waitWithPorts[portId]) return
+		_.each(this._waitWithPorts[portId], (fcn) => {
+			fcn(true)
+		})
 	}
 	/**
 	 * Returns true if the wait was cleared from someone else

--- a/packages/timeline-state-resolver/src/service/device.ts
+++ b/packages/timeline-state-resolver/src/service/device.ts
@@ -18,6 +18,8 @@ export type CommandWithContext = {
 	timelineObjId: string
 	/** this command is to be executed x ms _before_ the scheduled time */
 	preliminary?: number
+	/** commands with different queueId's can be executed in paralel in sequential mode */
+	queueId?: string
 }
 
 /**

--- a/packages/timeline-state-resolver/src/service/device.ts
+++ b/packages/timeline-state-resolver/src/service/device.ts
@@ -18,7 +18,7 @@ export type CommandWithContext = {
 	timelineObjId: string
 	/** this command is to be executed x ms _before_ the scheduled time */
 	preliminary?: number
-	/** commands with different queueId's can be executed in paralel in sequential mode */
+	/** commands with different queueId's can be executed in parallel in sequential mode */
 	queueId?: string
 }
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: 
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
All commands in an HTTPSend device are sent sequentially, ignoring the `queueId` property.


## New Behavior
<!--
What is the new behavior?
-->
HTTPSend device again supports the queueId property to allow separate sequential request queues.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->
* Ensure that HTTP integration still works as expected
* See if multiple parallel HTTP request can be made when using the queueId


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
