### PR TITLE
fix: using Sisyfos setChannel didn't send inputgain and input selector

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -134,6 +134,28 @@ export class SisyfosApi extends EventEmitter {
 					],
 				})
 			}
+			if (command.values.inputGain !== undefined) {
+				this._oscClient.send({
+					address: `/ch/${command.channel + 1}/inputgain`,
+					args: [
+						{
+							type: 'f',
+							value: command.values.inputGain,
+						},
+					],
+				})
+			}
+			if (command.values.inputSelector !== undefined) {
+				this._oscClient.send({
+					address: `/ch/${command.channel + 1}/inputselector`,
+					args: [
+						{
+							type: 'i',
+							value: command.values.inputSelector,
+						},
+					],
+				})
+			}
 			if (command.values.pgmOn !== undefined) {
 				const args: Array<MetaArgument> = [
 					{


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This PR is contributed on behalf of BBC
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->


## Type of Contribution

This is a: Bug fix
<!-- (pick one) -->
Bug fix / Feature / Code improvement / Documentation improvement / Other (please specify)


## Current Behavior
When using Sisyfos.setChannel() inputGain and inputSelector was not send to Sisyfos.
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->


## New Behavior
inputGain and inputSelector are now send to Sisyfos when using setChannel
<!--
What is the new behavior?
-->


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
