### PR TITLE
chore: add test cases for Sisyfos per-channel `triggerValue`

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
@@ -1099,18 +1099,20 @@ describe('Sisyfos', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('mySisyfos', {
-			type: DeviceType.SISYFOS,
-			options: {
-				host: '192.168.0.10',
-				port: 8900,
+		await addConnections(myConductor.connectionManager, {
+			mySisyfos: {
+				type: DeviceType.SISYFOS,
+				options: {
+					host: '192.168.0.10',
+					port: 8900,
+				},
+				commandReceiver: commandReceiver0,
 			},
-			commandReceiver: commandReceiver0,
 		})
 		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
-		const deviceContainer = myConductor.getDevice('mySisyfos')
+		const deviceContainer = myConductor.connectionManager.getConnection('mySisyfos')
 		const device = deviceContainer!.device as ThreadedClass<SisyfosMessageDevice>
 
 		// Check that no commands has been scheduled:
@@ -1249,18 +1251,20 @@ describe('Sisyfos', () => {
 			getCurrentTime: mockTime.getCurrentTime,
 		})
 		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
-		await myConductor.addDevice('mySisyfos', {
-			type: DeviceType.SISYFOS,
-			options: {
-				host: '192.168.0.10',
-				port: 8900,
+		await addConnections(myConductor.connectionManager, {
+			mySisyfos: {
+				type: DeviceType.SISYFOS,
+				options: {
+					host: '192.168.0.10',
+					port: 8900,
+				},
+				commandReceiver: commandReceiver0,
 			},
-			commandReceiver: commandReceiver0,
 		})
 		myConductor.setTimelineAndMappings([], myChannelMapping)
 		await mockTime.advanceTimeToTicks(10100)
 
-		const deviceContainer = myConductor.getDevice('mySisyfos')
+		const deviceContainer = myConductor.connectionManager.getConnection('mySisyfos')
 		const device = deviceContainer!.device as ThreadedClass<SisyfosMessageDevice>
 
 		// Check that no commands has been scheduled:

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
@@ -851,7 +851,7 @@ describe('Sisyfos', () => {
 		commandReceiver0.mockClear()
 	})
 
-	test('Sisyfos: using triggerValue', async () => {
+	test('Sisyfos: using global triggerValue', async () => {
 		const commandReceiver0: any = jest.fn(async () => {
 			return Promise.resolve()
 		})
@@ -1048,6 +1048,164 @@ describe('Sisyfos', () => {
 			},
 		})
 		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
+			type: 'setChannel',
+			channel: 2,
+			values: {
+				faderLevel: 0.2,
+				pgmOn: 0,
+			},
+		})
+
+		commandReceiver0.mockClear()
+	})
+
+	test('Sisyfos: using per-channel triggerValue', async () => {
+		const commandReceiver0: any = jest.fn(async () => {
+			return Promise.resolve()
+		})
+		const myChannelMapping0: Mapping<SomeMappingSisyfos> = {
+			device: DeviceType.SISYFOS,
+			deviceId: 'mySisyfos',
+			options: {
+				mappingType: MappingSisyfosType.Channels,
+			},
+		}
+		const myChannelMapping1: Mapping<SomeMappingSisyfos> = {
+			device: DeviceType.SISYFOS,
+			deviceId: 'mySisyfos',
+			options: {
+				mappingType: MappingSisyfosType.Channel,
+				channel: 1,
+				setLabelToLayerName: false,
+			},
+		}
+		const myChannelMapping2: Mapping<SomeMappingSisyfos> = {
+			device: DeviceType.SISYFOS,
+			deviceId: 'mySisyfos',
+			options: {
+				mappingType: MappingSisyfosType.Channel,
+				channel: 2,
+				setLabelToLayerName: false,
+			},
+		}
+		const myChannelMapping3: Mapping<SomeMappingSisyfos> = {
+			device: DeviceType.SISYFOS,
+			deviceId: 'mySisyfos',
+			options: {
+				mappingType: MappingSisyfosType.Channels,
+			},
+		}
+		const myChannelMapping: Mappings = {
+			sisyfos_channels_base: myChannelMapping0,
+			sisyfos_channel_1: myChannelMapping1,
+			sisyfos_channel_2: myChannelMapping2,
+			sisyfos_channels: myChannelMapping3,
+		}
+
+		const myConductor = new Conductor({
+			multiThreadedResolver: false,
+			getCurrentTime: mockTime.getCurrentTime,
+		})
+		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
+		await myConductor.addDevice('mySisyfos', {
+			type: DeviceType.SISYFOS,
+			options: {
+				host: '192.168.0.10',
+				port: 8900,
+			},
+			commandReceiver: commandReceiver0,
+		})
+		myConductor.setTimelineAndMappings([], myChannelMapping)
+		await mockTime.advanceTimeToTicks(10100)
+
+		const deviceContainer = myConductor.getDevice('mySisyfos')
+		const device = deviceContainer!.device as ThreadedClass<SisyfosMessageDevice>
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+		commandReceiver0.mockClear()
+
+		myConductor.setTimelineAndMappings([
+			{
+				id: 'baseline',
+				enable: {
+					while: 1,
+				},
+				layer: 'sisyfos_channels_base',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNELS,
+
+					channels: [
+						{
+							mappedLayer: 'sisyfos_channel_1',
+							faderLevel: 0.1,
+							isPgm: 0,
+						},
+						{
+							mappedLayer: 'sisyfos_channel_2',
+							faderLevel: 0.2,
+							isPgm: 0,
+						},
+					],
+					overridePriority: -999,
+					triggerValue: 'a',
+				},
+			},
+			{
+				id: 'obj1',
+				enable: {
+					start: mockTime.now + 1000, // 1 seconds in the future
+					duration: 10000,
+				},
+				layer: 'sisyfos_channel_2',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+
+					triggerValue: 'b',
+				},
+			},
+		])
+
+		// baseline:
+		await mockTime.advanceTimeTicks(100) // 100
+		expect(commandReceiver0.mock.calls.length).toEqual(2)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
+			type: 'setChannel',
+			channel: 1,
+			values: {
+				faderLevel: 0.1,
+				pgmOn: 0,
+			},
+		})
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
+			type: 'setChannel',
+			channel: 2,
+			values: {
+				faderLevel: 0.2,
+				pgmOn: 0,
+			},
+		})
+		commandReceiver0.mockClear()
+
+		// obj1 has started
+		await mockTime.advanceTimeTicks(1000) // 1100
+		expect(commandReceiver0.mock.calls.length).toEqual(1)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
+			type: 'setChannel',
+			channel: 2,
+			values: {
+				faderLevel: 0.2,
+				pgmOn: 0,
+			},
+		})
+		commandReceiver0.mockClear()
+
+		// back to baseline
+		await mockTime.advanceTimeTicks(10000) // 11100
+		expect(commandReceiver0.mock.calls.length).toEqual(1)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			type: 'setChannel',
 			channel: 2,
 			values: {

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
@@ -1059,7 +1059,7 @@ describe('Sisyfos', () => {
 		commandReceiver0.mockClear()
 	})
 
-	test('Sisyfos: using per-channel triggerValue', async () => {
+	test('Sisyfos: using per-channel triggerValue - initially defined', async () => {
 		const commandReceiver0: any = jest.fn(async () => {
 			return Promise.resolve()
 		})
@@ -1088,18 +1088,10 @@ describe('Sisyfos', () => {
 				setLabelToLayerName: false,
 			},
 		}
-		const myChannelMapping3: Mapping<SomeMappingSisyfos> = {
-			device: DeviceType.SISYFOS,
-			deviceId: 'mySisyfos',
-			options: {
-				mappingType: MappingSisyfosType.Channels,
-			},
-		}
 		const myChannelMapping: Mappings = {
 			sisyfos_channels_base: myChannelMapping0,
 			sisyfos_channel_1: myChannelMapping1,
 			sisyfos_channel_2: myChannelMapping2,
-			sisyfos_channels: myChannelMapping3,
 		}
 
 		const myConductor = new Conductor({
@@ -1213,6 +1205,148 @@ describe('Sisyfos', () => {
 				pgmOn: 0,
 			},
 		})
+
+		commandReceiver0.mockClear()
+	})
+
+	test('Sisyfos: using per-channel triggerValue - initially undefined', async () => {
+		const commandReceiver0: any = jest.fn(async () => {
+			return Promise.resolve()
+		})
+		const myChannelMapping0: Mapping<SomeMappingSisyfos> = {
+			device: DeviceType.SISYFOS,
+			deviceId: 'mySisyfos',
+			options: {
+				mappingType: MappingSisyfosType.Channels,
+			},
+		}
+		const myChannelMapping1: Mapping<SomeMappingSisyfos> = {
+			device: DeviceType.SISYFOS,
+			deviceId: 'mySisyfos',
+			options: {
+				mappingType: MappingSisyfosType.Channel,
+				channel: 1,
+				setLabelToLayerName: false,
+			},
+		}
+		const myChannelMapping2: Mapping<SomeMappingSisyfos> = {
+			device: DeviceType.SISYFOS,
+			deviceId: 'mySisyfos',
+			options: {
+				mappingType: MappingSisyfosType.Channel,
+				channel: 2,
+				setLabelToLayerName: false,
+			},
+		}
+		const myChannelMapping: Mappings = {
+			sisyfos_channels_base: myChannelMapping0,
+			sisyfos_channel_1: myChannelMapping1,
+			sisyfos_channel_2: myChannelMapping2,
+		}
+
+		const myConductor = new Conductor({
+			multiThreadedResolver: false,
+			getCurrentTime: mockTime.getCurrentTime,
+		})
+		await myConductor.init() // we cannot do an await, because setTimeout will never call without jest moving on.
+		await myConductor.addDevice('mySisyfos', {
+			type: DeviceType.SISYFOS,
+			options: {
+				host: '192.168.0.10',
+				port: 8900,
+			},
+			commandReceiver: commandReceiver0,
+		})
+		myConductor.setTimelineAndMappings([], myChannelMapping)
+		await mockTime.advanceTimeToTicks(10100)
+
+		const deviceContainer = myConductor.getDevice('mySisyfos')
+		const device = deviceContainer!.device as ThreadedClass<SisyfosMessageDevice>
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+		commandReceiver0.mockClear()
+
+		myConductor.setTimelineAndMappings([
+			{
+				id: 'baseline',
+				enable: {
+					while: 1,
+				},
+				layer: 'sisyfos_channels_base',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNELS,
+
+					channels: [
+						{
+							mappedLayer: 'sisyfos_channel_1',
+							faderLevel: 0.1,
+							isPgm: 0,
+						},
+						{
+							mappedLayer: 'sisyfos_channel_2',
+							faderLevel: 0.2,
+							isPgm: 0,
+						},
+					],
+					overridePriority: -999,
+					// triggerValue: 'a'
+				},
+			},
+			{
+				id: 'obj1',
+				enable: {
+					start: mockTime.now + 1000, // 1 seconds in the future
+					duration: 10000,
+				},
+				layer: 'sisyfos_channel_2',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.CHANNEL,
+
+					triggerValue: 'b',
+				},
+			},
+		])
+
+		// baseline:
+		await mockTime.advanceTimeTicks(100) // 100
+		expect(commandReceiver0.mock.calls.length).toEqual(2)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
+			type: 'setChannel',
+			channel: 1,
+			values: {
+				faderLevel: 0.1,
+				pgmOn: 0,
+			},
+		})
+		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
+			type: 'setChannel',
+			channel: 2,
+			values: {
+				faderLevel: 0.2,
+				pgmOn: 0,
+			},
+		})
+		commandReceiver0.mockClear()
+
+		// obj1 has started
+		await mockTime.advanceTimeTicks(1000) // 1100
+		expect(commandReceiver0.mock.calls.length).toEqual(1)
+		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
+			type: 'setChannel',
+			channel: 2,
+			values: {
+				faderLevel: 0.2,
+				pgmOn: 0,
+			},
+		})
+		commandReceiver0.mockClear()
+
+		// back to baseline
+		await mockTime.advanceTimeTicks(10000) // 11100
+		expect(commandReceiver0.mock.calls.length).toEqual(0)
 
 		commandReceiver0.mockClear()
 	})

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/__tests__/sisyfos.spec.ts
@@ -1318,20 +1318,14 @@ describe('Sisyfos', () => {
 		await mockTime.advanceTimeTicks(100) // 100
 		expect(commandReceiver0.mock.calls.length).toEqual(2)
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
-			type: 'setChannel',
+			type: 'setFader',
 			channel: 1,
-			values: {
-				faderLevel: 0.1,
-				pgmOn: 0,
-			},
+			values: [0.1],
 		})
 		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
-			type: 'setChannel',
+			type: 'setFader',
 			channel: 2,
-			values: {
-				faderLevel: 0.2,
-				pgmOn: 0,
-			},
+			values: [0.2],
 		})
 		commandReceiver0.mockClear()
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of TV 2 Norge.

## Type of Contribution

This is a: 
<!-- (pick one) -->
Other - increasing test coverage


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
Sisyfos per-channel `triggerValue` works correctly, but it isn't covered by tests

## New Behavior
<!--
What is the new behavior?
-->
Added two test cases asserting that the feature works in two scenarios:

- when the value changes from one to another, and back
- when the value changes from `undefined` to defined, and back

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
