### PR TITLE
feat(vMix): allow overriding vMix transition from a separate layer

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
@@ -71,6 +71,11 @@ export class VMixTimelineStateConverter {
 								this._switchToInput(content.input, deviceState, mixProgram, content.transition)
 							} else if (content.inputLayer) {
 								this._switchToInput(content.inputLayer, deviceState, mixProgram, content.transition, true)
+							} else if (content.transition) {
+								const mixState = deviceState.reportedState.mixes[mixProgram]
+								if (mixState) {
+									mixState.transition = content.transition
+								}
 							}
 						}
 						break
@@ -238,7 +243,7 @@ export class VMixTimelineStateConverter {
 			mixState.preview = mixState.program
 			mixState.program = input
 
-			mixState.transition = transition || { effect: VMixTransitionType.Cut, duration: 0 }
+			mixState.transition = transition ?? { effect: VMixTransitionType.Cut, duration: 0 }
 			mixState.layerToProgram = layerToProgram
 		}
 	}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge.

## Type of Contribution

This is a: 
<!-- (pick one) -->
Feature


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
It is not possible to use two separate `TimelineContentTypeVMix.PROGRAM` timeline objects to select the `input`, and the `transition` of a single mix independently.

## New Behavior
<!--
What is the new behavior?
-->
When two layer mappings are targeting the same mix, a timeline object on an alphabetically higher layer can be used to select the `transition`, while another one selects select the `input`.
Decoupling those two makes it much easier to override the transitions in Sofie, by simply adding an extra piece that selects the transition, without the need to modify the piece that changes the input and effectively performs the transition.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->
It can be tested by creating mappings and timeline objects as shown in the `'allows overriding transitions in usual layer order'` test case.

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
