### PR TITLE
feat(vMix): support index (list, photo, virtual set) in vMix

### DIFF
--- a/packages/timeline-state-resolver-types/src/integrations/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/vmix.ts
@@ -45,6 +45,7 @@ export enum VMixCommand {
 	LIST_ADD = 'LIST_ADD',
 	LIST_REMOVE_ALL = 'LIST_REMOVE_ALL',
 	RESTART_INPUT = 'RESTART_INPUT',
+	SELECT_INDEX = 'SELECT_INDEX',
 }
 
 export type TimelineContentVMixAny =
@@ -188,6 +189,13 @@ export interface TimelineContentVMixInput extends TimelineContentVMixBase {
 
 	/** If media should start from the beginning or resume from where it left off */
 	restart?: boolean
+
+	/**
+	 * Photos, List: Selects item in List
+	 * Virtual Set: Zooms to selected preset using the current speed settings
+	 * starts from 1
+	 */
+	index?: number
 }
 
 export interface TimelineContentVMixOutput extends TimelineContentVMixBase {

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/connection.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/connection.spec.ts
@@ -92,4 +92,19 @@ describe('VMixCommandSender', () => {
 			value: 1.5,
 		})
 	})
+
+	it('selects index', async () => {
+		const { sender, mockConnection } = createTestee()
+		await sender.sendCommand({
+			command: VMixCommand.SELECT_INDEX,
+			input: 5,
+			value: 3,
+		})
+
+		expect(mockConnection.sendCommandFunction).toHaveBeenCalledTimes(1)
+		expect(mockConnection.sendCommandFunction).toHaveBeenLastCalledWith('SelectIndex', {
+			input: 5,
+			value: 3,
+		})
+	})
 })

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixStateDiffer.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixStateDiffer.spec.ts
@@ -146,4 +146,26 @@ describe('VMixStateDiffer', () => {
 			cropBottom: 0.8,
 		})
 	})
+
+	it('sets index', () => {
+		const differ = createTestee()
+
+		const oldState = makeMockFullState()
+		const newState = makeMockFullState()
+
+		oldState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+
+		newState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+		const index = 3
+		newState.reportedState.existingInputs['99'].index = index
+
+		const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+		expect(commands.length).toBe(1)
+		expect(commands[0].command).toMatchObject({
+			command: VMixCommand.SELECT_INDEX,
+			input: '99',
+			value: index,
+		})
+	})
 })

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixTimelineStateConverter.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixTimelineStateConverter.spec.ts
@@ -136,6 +136,27 @@ describe('VMixTimelineStateConverter', () => {
 			expect(result.reportedState.inputsAddedByUsAudio[prefixAddedInput(filePath)]).toBeUndefined()
 		})
 
+		it('supports index', () => {
+			const converter = createTestee()
+			const index = 3
+			const result = converter.getVMixStateFromTimelineState(
+				wrapInTimelineState({
+					inp0: wrapInTimelineObject('inp0', {
+						deviceType: DeviceType.VMIX,
+						index,
+						type: TimelineContentTypeVMix.INPUT,
+					}),
+				}),
+				{
+					inp0: wrapInMapping({
+						mappingType: MappingVmixType.Input,
+						index: '1',
+					}),
+				}
+			)
+			expect(result.reportedState.existingInputs['1'].index).toEqual(index)
+		})
+
 		// TODO: maybe we can't trust the defaults when adding an input? Make this test pass eventually
 		// it('tracks audio state for mapped inputs added by us', () => {
 		// 	const converter = createTestee()

--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -260,6 +260,8 @@ export class VMixCommandSender {
 				return this.listRemoveAll(command.input)
 			case VMixCommand.RESTART_INPUT:
 				return this.restart(command.input)
+			case VMixCommand.SELECT_INDEX:
+				return this.selectIndex(command.input, command.value)
 			default:
 				throw new Error(`vmixAPI: Command ${((command || {}) as any).command} not implemented`)
 		}
@@ -465,6 +467,10 @@ export class VMixCommandSender {
 
 	public async restart(input: string | number): Promise<any> {
 		return this.sendCommandFunction(`Restart`, { input })
+	}
+
+	public async selectIndex(input: string | number, value: number): Promise<any> {
+		return this.sendCommandFunction(`SelectIndex`, { input, value })
 	}
 
 	private async sendCommandFunction(func: string, args: SentCommandArgs) {

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
@@ -203,6 +203,11 @@ export interface VMixStateCommandRestart extends VMixStateCommandBase {
 	command: VMixCommand.RESTART_INPUT
 	input: string | number
 }
+export interface VMixStateCommanSelectIndex extends VMixStateCommandBase {
+	command: VMixCommand.SELECT_INDEX
+	input: string | number
+	value: number
+}
 export type VMixStateCommand =
 	| VMixStateCommandPreviewInput
 	| VMixStateCommandTransition
@@ -248,6 +253,7 @@ export type VMixStateCommand =
 	| VMixStateCommandListAdd
 	| VMixStateCommandListRemoveAll
 	| VMixStateCommandRestart
+	| VMixStateCommanSelectIndex
 
 export enum CommandContext {
 	None = 'none',

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixStateDiffer.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixStateDiffer.ts
@@ -78,6 +78,7 @@ export interface VMixInput {
 	layers?: VMixLayers
 	listFilePaths?: string[]
 	restart?: boolean
+	index?: number
 }
 
 export interface VMixInputAudio {
@@ -578,6 +579,17 @@ export class VMixStateDiffer {
 				command: {
 					command: VMixCommand.PLAY_INPUT,
 					input: input.name,
+				},
+				context: CommandContext.None,
+				timelineId: '',
+			})
+		}
+		if (input.index !== undefined && oldInput.index !== input.index) {
+			commands.push({
+				command: {
+					command: VMixCommand.SELECT_INDEX,
+					input: key,
+					value: input.index,
 				},
 				context: CommandContext.None,
 				timelineId: '',

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
@@ -143,6 +143,7 @@ export class VMixTimelineStateConverter {
 										(content.overlays ? this._convertDeprecatedInputOverlays(content.overlays) : undefined),
 									listFilePaths: content.listFilePaths,
 									restart: content.restart,
+									index: content.index,
 								},
 								{ key: mapping.options.index, filePath: content.filePath },
 								layerName


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge

## Type of Contribution

This is a: 
<!-- (pick one) -->
Feature 

## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
_Index_ of inputs of types Photos, List and Virtual Set cannot be controlled by TSR.

## New Behavior
<!--
What is the new behavior?
-->
_Index_ of inputs of types: 
- Photos, List (Selects the item in the list)
- Virtual Set (Zooms to selected preset using the current speed settings)

...can be controlled by the added `index` property of `TimelineContentVMixInput`, resulting in issuing the `SelectIndex` command.
The index starts from 1, which is not how indexes should work, but I'm following vMix's convention here.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

1. Add an input of one of the three mentioned types, with more than one item(preset)
2. Create a mapping and a timeline object as shown in the `'supports index'` test case
3. Verify that the index changes when the timeline object starts

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
