### PR TITLE
feat(Sisyfos): add sisyfos action to load mixer preset

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
+++ b/packages/timeline-state-resolver-types/src/generated/sisyfos.ts
@@ -38,13 +38,22 @@ export interface SetSisyfosChannelStatePayload {
 	channel: number
 }
 
+export interface LoadMixerPresetPayload {
+	/**
+	 * The name of the preset to load
+	 */
+	name: string
+}
+
 export enum SisyfosActions {
 	Reinit = 'reinit',
-	SetSisyfosChannelState = 'setSisyfosChannelState'
+	SetSisyfosChannelState = 'setSisyfosChannelState',
+	LoadMixerPreset = 'loadMixerPreset'
 }
 export interface SisyfosActionExecutionResults {
 	reinit: () => void,
-	setSisyfosChannelState: (payload: SetSisyfosChannelStatePayload) => void
+	setSisyfosChannelState: (payload: SetSisyfosChannelStatePayload) => void,
+	loadMixerPreset: (payload: LoadMixerPresetPayload) => void
 }
 export type SisyfosActionExecutionPayload<A extends keyof SisyfosActionExecutionResults> = Parameters<
 	SisyfosActionExecutionResults[A]

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/$schemas/actions.json
@@ -22,6 +22,23 @@
 			},
 			"destructive": false,
 			"timeout": 5000
+		},
+		{
+			"id": "loadMixerPreset",
+			"name": "Load Mixer Preset",
+			"destructive": false,
+			"timeout": 5000,
+			"payload": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "The name of the preset to load",
+						"type": "string"
+					}
+				},
+				"required": ["name"],
+				"additionalProperties": false
+			}
 		}
 	]
 }

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/connection.ts
@@ -176,6 +176,8 @@ export class SisyfosApi extends EventEmitter<SisyfosApiEvents> {
 				...command.values,
 			}
 			this.setSisyfosChannel(command.channel + 1, channelState)
+		} else if (command.type === SisyfosCommandType.LOAD_MIXER_PRESET) {
+			this.sendLoadMixerPresetCommand(command.presetName)
 		}
 	}
 
@@ -371,6 +373,21 @@ export class SisyfosApi extends EventEmitter<SisyfosApiEvents> {
 
 		return deviceState
 	}
+
+	protected sendLoadMixerPresetCommand(presetName: string) {
+		if (!this._oscClient) {
+			throw new Error(`Can't load mixer preset, OSC client not initialised`)
+		}
+		this._oscClient.send({
+			address: `/loadmixerpreset`,
+			args: [
+				{
+					type: 's',
+					value: presetName,
+				},
+			],
+		})
+	}
 }
 
 export enum SisyfosCommandType {
@@ -387,6 +404,7 @@ export enum SisyfosCommandType {
 	RESYNC = 'resync',
 	RESYNC_CHANNEL = 'resyncChannel',
 	SET_CHANNEL = 'setChannel',
+	LOAD_MIXER_PRESET = 'loadMixerPreset',
 }
 
 export interface BaseCommand {
@@ -397,6 +415,11 @@ export interface SetChannelCommand {
 	type: SisyfosCommandType.SET_CHANNEL
 	channel: number
 	values: Partial<SisyfosChannelAPI>
+}
+
+export interface LoadMixerPresetCommand {
+	type: SisyfosCommandType.LOAD_MIXER_PRESET
+	presetName: string
 }
 
 export interface ChannelCommand extends BaseCommand {
@@ -411,6 +434,10 @@ export interface ChannelCommand extends BaseCommand {
 		| SisyfosCommandType.SET_INPUT_GAIN
 		| SisyfosCommandType.SET_MUTE
 	channel: number
+}
+
+export interface GlobalCommand extends BaseCommand {
+	type: SisyfosCommandType.CLEAR_PST_ROW | SisyfosCommandType.TAKE | SisyfosCommandType.RESYNC
 }
 
 export interface GlobalCommand extends BaseCommand {
@@ -448,6 +475,7 @@ export type SisyfosCommand =
 	| BoolCommand
 	| StringCommand
 	| SetChannelCommand
+	| LoadMixerPresetCommand
 
 export interface SisyfosChannel extends SisyfosChannelAPI {
 	timelineObjIds: string[]


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge


## Type of Contribution

This is a: 
<!-- (pick one) -->
Feature 

## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
No way to load a mixer preset using TSR.

## New Behavior
<!--
What is the new behavior?
-->
TSR action is added, that allows to load a specified mixer preset.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->
~~It's a draft, because complementary changes haven't been yet contributed upstream in Sisyfos~~
Complementary changes in Sisyfos: https://github.com/olzzon/sisyfos-audio-controller/pull/8/commits/858d237c08523ada2589d62741f1fc95cf4626c0

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
