### PR TITLE
feat(EAV-423): add actions to start and stop External in vMix

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vmix.ts
@@ -125,12 +125,16 @@ export interface SavePresetPayload {
 export enum VmixActions {
 	LastPreset = 'lastPreset',
 	OpenPreset = 'openPreset',
-	SavePreset = 'savePreset'
+	SavePreset = 'savePreset',
+	StartExternal = 'startExternal',
+	StopExternal = 'stopExternal'
 }
 export interface VmixActionExecutionResults {
 	lastPreset: () => void,
 	openPreset: (payload: OpenPresetPayload) => void,
-	savePreset: (payload: SavePresetPayload) => void
+	savePreset: (payload: SavePresetPayload) => void,
+	startExternal: () => void,
+	stopExternal: () => void
 }
 export type VmixActionExecutionPayload<A extends keyof VmixActionExecutionResults> = Parameters<
 	VmixActionExecutionResults[A]

--- a/packages/timeline-state-resolver/src/integrations/vmix/$schemas/actions.json
+++ b/packages/timeline-state-resolver/src/integrations/vmix/$schemas/actions.json
@@ -41,6 +41,18 @@
 				"required": ["filename"],
 				"additionalProperties": false
 			}
+		},
+		{
+			"id": "startExternal",
+			"name": "Start External Output",
+			"destructive": false,
+			"timeout": 5000
+		},
+		{
+			"id": "stopExternal",
+			"name": "Stop External Output",
+			"destructive": false,
+			"timeout": 5000
 		}
 	]
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge

## Type of Contribution

This is a: 
<!-- (pick one) -->
Feature


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
No TSR actions to start/stop External output in vMix

## New Behavior
<!--
What is the new behavior?
-->
TSR actions to start/stop External output in vMix are added.
Note: Those actions are not taking the _External_ mapping and timeline objects into consideration. To avoid undefined behavior, either use the timeline or the actions to control the External output, not both.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->
When used with Sofie, it can be tested using the autogenerated buttons in the Playout Gateway section of Sofie settings.
Press _Start External_ and verify if the _External_ indicator lit up red in vMix.
Press _Stop External_ and verify if the _External_ indicator went back to grey in vMix.

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
