### PR TITLE
feat(EAV-464): add images support for GT titles in vMix

### DIFF
--- a/packages/timeline-state-resolver-types/src/integrations/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/vmix.ts
@@ -48,6 +48,7 @@ export enum VMixCommand {
 	SET_TEXT = 'SET_TEXT',
 	BROWSER_NAVIGATE = 'BROWSER_NAVIGATE',
 	SELECT_INDEX = 'SELECT_INDEX',
+	SET_IMAGE = 'SET_IMAGE',
 }
 
 export type TimelineContentVMixAny =
@@ -206,6 +207,11 @@ export interface TimelineContentVMixInput extends TimelineContentVMixBase {
 	 * starts from 1
 	 */
 	index?: number
+
+	/**
+	 * Titles (GT): Sets the filenames of image fields by name
+	 */
+	images?: VMixImages
 }
 
 export interface TimelineContentVMixOutput extends TimelineContentVMixBase {
@@ -262,6 +268,10 @@ export interface VMixInputOverlays {
 }
 
 export interface VMixText {
+	[index: string]: string
+}
+
+export interface VMixImages {
 	[index: string]: string
 }
 

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixStateDiffer.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixStateDiffer.spec.ts
@@ -323,4 +323,138 @@ describe('VMixStateDiffer', () => {
 			value: index,
 		})
 	})
+
+	it('sets images', () => {
+		const differ = createTestee()
+
+		const oldState = makeMockFullState()
+		const newState = makeMockFullState()
+
+		oldState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+
+		newState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+
+		newState.reportedState.existingInputs['99'].images = {
+			'myImage.Source': 'image.png',
+		}
+
+		const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+		expect(commands.length).toBe(1)
+		expect(commands[0].command).toMatchObject({
+			command: VMixCommand.SET_IMAGE,
+			input: '99',
+			value: 'image.png',
+			fieldName: 'myImage.Source',
+		})
+	})
+
+	it('sets multiple images', () => {
+		const differ = createTestee()
+
+		const oldState = makeMockFullState()
+		const newState = makeMockFullState()
+
+		oldState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+
+		newState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+
+		newState.reportedState.existingInputs['99'].images = {
+			'myImage1.Source': 'foo.png',
+			'myImage2.Source': 'bar.jpg',
+		}
+
+		const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+		expect(commands.length).toBe(2)
+		expect(commands[0].command).toMatchObject({
+			command: VMixCommand.SET_IMAGE,
+			input: '99',
+			value: 'foo.png',
+			fieldName: 'myImage1.Source',
+		})
+		expect(commands[1].command).toMatchObject({
+			command: VMixCommand.SET_IMAGE,
+			input: '99',
+			value: 'bar.jpg',
+			fieldName: 'myImage2.Source',
+		})
+	})
+
+	it('does not unset image', () => {
+		// it would have to be explicitly set to an empty string on the timeline
+		const differ = createTestee()
+
+		const oldState = makeMockFullState()
+		const newState = makeMockFullState()
+
+		oldState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+		oldState.reportedState.existingInputs['99'].images = {
+			'myImage1.Source': 'foo.png',
+			'myImage2.Source': 'bar.jpg',
+		}
+
+		newState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+		newState.reportedState.existingInputs['99'].images = {
+			'myImage2.Source': 'bar.jpg',
+		}
+
+		const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+		expect(commands.length).toBe(0)
+	})
+
+	it('updates image', () => {
+		const differ = createTestee()
+
+		const oldState = makeMockFullState()
+		const newState = makeMockFullState()
+
+		oldState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+		oldState.reportedState.existingInputs['99'].images = {
+			'myImage1.Source': 'foo.png',
+		}
+
+		newState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+		newState.reportedState.existingInputs['99'].images = {
+			'myImage1.Source': 'bar.jpg',
+		}
+
+		const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+		expect(commands.length).toBe(1)
+		expect(commands[0].command).toMatchObject({
+			command: VMixCommand.SET_IMAGE,
+			input: '99',
+			value: 'bar.jpg',
+			fieldName: 'myImage1.Source',
+		})
+	})
+
+	it('updates image to an empty one', () => {
+		const differ = createTestee()
+
+		const oldState = makeMockFullState()
+		const newState = makeMockFullState()
+
+		oldState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+		oldState.reportedState.existingInputs['99'].images = {
+			'myImage1.Source': 'foo.png',
+		}
+
+		newState.reportedState.existingInputs['99'] = differ.getDefaultInputState(99)
+		newState.reportedState.existingInputs['99'].images = {
+			'myImage1.Source': '',
+		}
+
+		const commands = differ.getCommandsToAchieveState(Date.now(), oldState, newState)
+
+		expect(commands.length).toBe(1)
+		expect(commands[0].command).toMatchObject({
+			command: VMixCommand.SET_IMAGE,
+			input: '99',
+			value: '',
+			fieldName: 'myImage1.Source',
+		})
+	})
 })

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixTimelineStateConverter.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixTimelineStateConverter.spec.ts
@@ -266,6 +266,27 @@ describe('VMixTimelineStateConverter', () => {
 			expect(result.reportedState.existingInputs['1'].index).toEqual(index)
 		})
 
+		it('supports images (titles)', () => {
+			const converter = createTestee()
+			const images = { 'myImage1.Source': 'foo.png', 'myImage2.Source': 'bar.jpg' }
+			const result = converter.getVMixStateFromTimelineState(
+				wrapInTimelineState({
+					inp0: wrapInTimelineObject('inp0', {
+						deviceType: DeviceType.VMIX,
+						images,
+						type: TimelineContentTypeVMix.INPUT,
+					}),
+				}),
+				{
+					inp0: wrapInMapping({
+						mappingType: MappingVmixType.Input,
+						index: '1',
+					}),
+				}
+			)
+			expect(result.reportedState.existingInputs['1'].images).toEqual(images)
+		})
+
 		// TODO: maybe we can't trust the defaults when adding an input? Make this test pass eventually
 		// it('tracks audio state for mapped inputs added by us', () => {
 		// 	const converter = createTestee()

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixXmlStateParser.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixXmlStateParser.spec.ts
@@ -269,4 +269,31 @@ describe('VMixXmlStateParser', () => {
 			},
 		})
 	})
+
+	it('parses images (titles)', () => {
+		const parser = new VMixXmlStateParser()
+
+		const parsedState = parser.parseVMixState(
+			makeMockVMixXmlState([
+				'<input key="a97b8de1-807a-4c14-8eb9-3de0129b41e3" number="1" type="Capture" title="Cam 0" state="Running" position="0" duration="0" loop="False" muted="False" volume="100" balance="0" solo="False" audiobusses="M" meterF1="0.03034842" meterF2="0.03034842"></input>',
+				`<input key="ca9bc59f-f698-41fe-b17d-1e1743cfee88" number="2" type="GT" title="gfx.gtzip" shortTitle="gfx.gtzip" state="Paused" position="0" duration="0" loop="False" >
+	gfx.gtzip
+	<image index="0" name="SomeImage.Source">image1.png</image>
+	<image index="1" name="AnotherImage.Source">image2.jpg</image>
+</input>`,
+				'<input key="1d70bc59-6517-4571-a0c5-932e30311f01" number="3" type="Capture" title="Cam 2" state="Running" position="0" duration="0" loop="False" muted="False" volume="100" balance="0" solo="False" audiobusses="M" meterF1="0.03034842" meterF2="0.03034842"></input>',
+			])
+		)
+
+		expect(parsedState).toMatchObject<Partial<VMixState>>({
+			existingInputs: {
+				'2': {
+					images: {
+						'SomeImage.Source': 'image1.png',
+						'AnotherImage.Source': 'image2.jpg',
+					},
+				},
+			},
+		})
+	})
 })

--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -260,6 +260,8 @@ export class VMixCommandSender {
 				return this.browserNavigate(command.input, command.value)
 			case VMixCommand.SELECT_INDEX:
 				return this.selectIndex(command.input, command.value)
+			case VMixCommand.SET_IMAGE:
+				return this.setImage(command.input, command.value, command.fieldName)
 			default:
 				throw new Error(`vmixAPI: Command ${((command || {}) as any).command} not implemented`)
 		}
@@ -477,6 +479,10 @@ export class VMixCommandSender {
 
 	public async selectIndex(input: string | number, value: number): Promise<any> {
 		return this.sendCommandFunction(`SelectIndex`, { input, value })
+	}
+
+	public async setImage(input: string | number, value: string, fieldName: string): Promise<any> {
+		return this.sendCommandFunction(`SetImage`, { input, value: encodeURIComponent(value), selectedName: fieldName })
 	}
 
 	private async sendCommandFunction(func: string, args: SentCommandArgs) {

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
@@ -219,6 +219,12 @@ export interface VMixStateCommanSelectIndex extends VMixStateCommandBase {
 	input: string | number
 	value: number
 }
+export interface VMixStateCommandSetImage extends VMixStateCommandBase {
+	command: VMixCommand.SET_IMAGE
+	input: string | number
+	fieldName: string
+	value: string
+}
 export type VMixStateCommand =
 	| VMixStateCommandPreviewInput
 	| VMixStateCommandTransition
@@ -267,6 +273,7 @@ export type VMixStateCommand =
 	| VMixStateCommandSetText
 	| VMixStateCommandBrowserNavigate
 	| VMixStateCommanSelectIndex
+	| VMixStateCommandSetImage
 
 export enum CommandContext {
 	None = 'none',

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixStateDiffer.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixStateDiffer.ts
@@ -7,6 +7,7 @@ import {
 	VMixTransitionType,
 	VMixLayer,
 	VMixText,
+	VMixImages,
 } from 'timeline-state-resolver-types'
 import { CommandContext, VMixStateCommandWithContext } from './vMixCommands'
 import _ = require('underscore')
@@ -82,6 +83,7 @@ export interface VMixInput {
 	text?: VMixText
 	url?: string
 	index?: number
+	images?: VMixImages
 }
 
 export interface VMixInputAudio {
@@ -624,6 +626,22 @@ export class VMixStateDiffer {
 				context: CommandContext.None,
 				timelineId: '',
 			})
+		}
+		if (input.images !== undefined) {
+			for (const [fieldName, value] of Object.entries<string>(input.images)) {
+				if (oldInput?.images?.[fieldName] !== value) {
+					commands.push({
+						command: {
+							command: VMixCommand.SET_IMAGE,
+							input: key,
+							value,
+							fieldName,
+						},
+						context: CommandContext.None,
+						timelineId: '',
+					})
+				}
+			}
 		}
 		return { preTransitionCommands, postTransitionCommands }
 	}

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
@@ -151,6 +151,7 @@ export class VMixTimelineStateConverter {
 									text: content.text,
 									url: content.url,
 									index: content.index,
+									images: content.images,
 								},
 								{ key: mapping.options.index, filePath: content.filePath },
 								layerName

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixXmlStateParser.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixXmlStateParser.ts
@@ -58,6 +58,14 @@ export class VMixXmlStateParser {
 				})
 			}
 
+			let images: VMixInput['images'] = undefined
+			if (input['image'] != null) {
+				this.ensureArray(input['image']).forEach((item) => {
+					images ??= {}
+					images[item['_attributes']['name']] = item['_text']
+				})
+			}
+
 			const result: VMixInput = {
 				number: inputNumber,
 				type: input['_attributes']['type'],
@@ -77,6 +85,7 @@ export class VMixXmlStateParser {
 				layers,
 				listFilePaths: fixedListFilePaths!,
 				text,
+				images,
 			}
 
 			const resultAudio = {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge

## Type of Contribution

This is a: 
<!-- (pick one) -->
Feature


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
Image fields in Title inputs in vMix cannot be controlled by TSR.

## New Behavior
<!--
What is the new behavior?
-->
Image fields in Title inputs in vMix can be controlled, using the newly added `images` property of TimelineContentVMixInput. They can only be addressed by the field name (a.k.a selected name), not by the index.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

1. Add a Title input that contains a dynamic image field
2. Create a mapping and a timeline object similar to those in the `'supports images (titles)'` test case, using field name(s) existing in the selected title template
3. Verify that the images for specified field name(s) change when the timeline object starts

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
