### PR TITLE
feat: add basic support for vMix audio buses

### DIFF
--- a/packages/timeline-state-resolver-types/src/generated/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/generated/vmix.ts
@@ -51,6 +51,14 @@ export interface MappingVmixAudioChannel {
 	mappingType: MappingVmixType.AudioChannel
 }
 
+export interface MappingVmixAudioBus {
+	/**
+	 * Name (letter) of the bus
+	 */
+	index: 'M' | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G'
+	mappingType: MappingVmixType.AudioBus
+}
+
 export interface MappingVmixOutput {
 	/**
 	 * Output
@@ -96,6 +104,7 @@ export enum MappingVmixType {
 	Preview = 'preview',
 	Input = 'input',
 	AudioChannel = 'audioChannel',
+	AudioBus = 'audioBus',
 	Output = 'output',
 	Overlay = 'overlay',
 	Recording = 'recording',
@@ -106,7 +115,7 @@ export enum MappingVmixType {
 	Script = 'script',
 }
 
-export type SomeMappingVmix = MappingVmixProgram | MappingVmixPreview | MappingVmixInput | MappingVmixAudioChannel | MappingVmixOutput | MappingVmixOverlay | MappingVmixRecording | MappingVmixStreaming | MappingVmixExternal | MappingVmixFadeToBlack | MappingVmixFader | MappingVmixScript
+export type SomeMappingVmix = MappingVmixProgram | MappingVmixPreview | MappingVmixInput | MappingVmixAudioChannel | MappingVmixAudioBus | MappingVmixOutput | MappingVmixOverlay | MappingVmixRecording | MappingVmixStreaming | MappingVmixExternal | MappingVmixFadeToBlack | MappingVmixFader | MappingVmixScript
 
 export interface OpenPresetPayload {
 	/**

--- a/packages/timeline-state-resolver-types/src/integrations/vmix.ts
+++ b/packages/timeline-state-resolver-types/src/integrations/vmix.ts
@@ -3,6 +3,8 @@ import { DeviceType } from '..'
 export enum VMixCommand {
 	PREVIEW_INPUT = 'PREVIEW_INPUT',
 	TRANSITION = 'TRANSITION',
+
+	// input audio
 	AUDIO_VOLUME = 'AUDIO_VOLUME',
 	AUDIO_BALANCE = 'AUDIO_BALANCE',
 	AUDIO_ON = 'AUDIO_ON',
@@ -11,7 +13,15 @@ export enum VMixCommand {
 	AUDIO_AUTO_OFF = 'AUDIO_AUTO_OFF',
 	AUDIO_BUS_ON = 'AUDIO_BUS_ON',
 	AUDIO_BUS_OFF = 'AUDIO_BUS_OFF',
+
+	// audio bus
+	BUS_AUDIO_ON = 'BUS_AUDIO_ON',
+	BUS_AUDIO_OFF = 'BUS_AUDIO_OFF',
+	BUS_VOLUME = 'BUS_VOLUME',
+
+	// the T-bar
 	FADER = 'FADER',
+
 	SET_PAN_X = 'SET_PAN_X',
 	SET_PAN_Y = 'SET_PAN_Y',
 	SET_ZOOM = 'SET_ZOOM',
@@ -55,6 +65,7 @@ export type TimelineContentVMixAny =
 	| TimelineContentVMixProgram
 	| TimelineContentVMixPreview
 	| TimelineContentVMixAudio
+	| TimelineContentVMixAudioBus
 	| TimelineContentVMixFader
 	| TimelineContentVMixRecording
 	| TimelineContentVMixStreaming
@@ -69,6 +80,7 @@ export enum TimelineContentTypeVMix {
 	PROGRAM = 'PROGRAM',
 	PREVIEW = 'PREVIEW',
 	AUDIO = 'AUDIO',
+	AUDIO_BUS = 'AUDIO_BUS',
 	FADER = 'FADER',
 	STREAMING = 'STREAMING',
 	RECORDING = 'RECORDING',
@@ -124,6 +136,16 @@ export interface TimelineContentVMixAudio extends TimelineContentVMixBase {
 
 	/** Audio follow video */
 	audioAuto?: boolean
+}
+
+export interface TimelineContentVMixAudioBus extends TimelineContentVMixBase {
+	type: TimelineContentTypeVMix.AUDIO_BUS
+
+	/** Bus volume (0 - 100) */
+	volume?: number
+
+	/** If bus is muted */
+	muted?: boolean
 }
 
 export interface TimelineContentVMixFader extends TimelineContentVMixBase {

--- a/packages/timeline-state-resolver/src/integrations/vmix/$schemas/mappings.json
+++ b/packages/timeline-state-resolver/src/integrations/vmix/$schemas/mappings.json
@@ -65,6 +65,20 @@
 			"required": [],
 			"additionalProperties": false
 		},
+		"audioBus": {
+			"type": "object",
+			"properties": {
+				"index": {
+					"type": "string",
+					"ui:title": "Index",
+					"ui:summaryTitle": "Index",
+					"description": "Name (letter) of the bus",
+					"enum": ["M", "A", "B", "C", "D", "E", "F", "G"]
+				}
+			},
+			"required": ["index"],
+			"additionalProperties": false
+		},
 		"output": {
 			"type": "object",
 			"properties": {

--- a/packages/timeline-state-resolver/src/integrations/vmix/README.md
+++ b/packages/timeline-state-resolver/src/integrations/vmix/README.md
@@ -6,6 +6,7 @@ Similarly to the TriCaster integration, only resources (features) that have corr
 
 - inputs - each input individually, when a corresponding mapping of type `MappingVmixType.Input` exists
 - audio channels - each audio channel (input), when a corresponding mapping of type `MappingVmixType.AudioChannel` exists
+- audio buses - each audio bus, when a corresponding mapping of type `MappingVmixType.AudioBus` exists
 - outputs - each output individually, when a corresponding mapping of type `MappingVmixType.Output` exists
 - overlays - each overlay individually, when a corresponding mapping of type `MappingVmixType.Overlay` exists
 - recording - when a mapping of type `MappingVmixType.Recording` exists

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/mockState.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/mockState.ts
@@ -140,15 +140,40 @@ export function makeMockReportedState(): VMixState {
 		playlist: false,
 		multiCorder: false,
 		fullscreen: false,
-		audio: [
-			{
+		audioBuses: {
+			M: {
+				muted: true,
 				volume: 100,
-				muted: false,
-				meterF1: 0.04211706,
-				meterF2: 0.04211706,
-				headphonesVolume: 74.80521,
 			},
-		],
+			A: {
+				muted: true,
+				volume: 100,
+			},
+			B: {
+				muted: true,
+				volume: 100,
+			},
+			C: {
+				muted: true,
+				volume: 100,
+			},
+			D: {
+				muted: true,
+				volume: 100,
+			},
+			E: {
+				muted: true,
+				volume: 100,
+			},
+			F: {
+				muted: true,
+				volume: 100,
+			},
+			G: {
+				muted: true,
+				volume: 100,
+			},
+		},
 	}
 }
 

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixTimelineStateConverter.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixTimelineStateConverter.spec.ts
@@ -21,11 +21,7 @@ function createTestee(): VMixTimelineStateConverter {
 			//
 		}
 	) // should those be mocks? or should this be taken from somewhere else? this is now more of an integration test, and maybe that's fine?
-	return new VMixTimelineStateConverter(
-		() => stateDiffer.getDefaultState(),
-		(inputNumber) => stateDiffer.getDefaultInputState(inputNumber),
-		(inputNumber) => stateDiffer.getDefaultInputAudioState(inputNumber)
-	)
+	return new VMixTimelineStateConverter(stateDiffer)
 }
 
 function wrapInTimelineState(
@@ -285,6 +281,27 @@ describe('VMixTimelineStateConverter', () => {
 				}
 			)
 			expect(result.reportedState.existingInputs['1'].images).toEqual(images)
+		})
+
+		it('supports audio buses', () => {
+			const converter = createTestee()
+			const bus = { muted: false, volume: 50 }
+			const result = converter.getVMixStateFromTimelineState(
+				wrapInTimelineState({
+					inp0: wrapInTimelineObject('inp0', {
+						deviceType: DeviceType.VMIX,
+						...bus,
+						type: TimelineContentTypeVMix.AUDIO_BUS,
+					}),
+				}),
+				{
+					inp0: wrapInMapping({
+						mappingType: MappingVmixType.AudioBus,
+						index: 'B',
+					}),
+				}
+			)
+			expect(result.reportedState.audioBuses.B).toEqual(bus)
 		})
 
 		// TODO: maybe we can't trust the defaults when adding an input? Make this test pass eventually

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixXmlStateParser.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vMixXmlStateParser.spec.ts
@@ -1,5 +1,5 @@
 import { VMixTransitionType } from 'timeline-state-resolver-types'
-import { VMixState } from '../vMixStateDiffer'
+import { VMixAudioBusesState, VMixState } from '../vMixStateDiffer'
 import { VMixXmlStateParser } from '../vMixXmlStateParser'
 import { makeMockVMixXmlState } from './vmixMock'
 import { prefixAddedInput } from './mockState'
@@ -93,15 +93,55 @@ describe('VMixXmlStateParser', () => {
 			playlist: false,
 			multiCorder: false,
 			fullscreen: false,
-			audio: [
-				{
-					volume: 100,
+			audioBuses: {
+				M: {
 					muted: false,
-					meterF1: 0.04211706,
-					meterF2: 0.04211706,
+					volume: 100,
 					headphonesVolume: 74.80521,
 				},
-			],
+				A: {
+					muted: false,
+					volume: 100,
+					sendToMaster: false,
+					solo: false,
+				},
+				B: {
+					muted: false,
+					volume: 78.07491,
+					sendToMaster: false,
+					solo: false,
+				},
+				C: {
+					muted: false,
+					volume: 100,
+					sendToMaster: false,
+					solo: false,
+				},
+				D: {
+					muted: false,
+					volume: 100,
+					sendToMaster: false,
+					solo: false,
+				},
+				E: {
+					muted: true,
+					volume: 100,
+					sendToMaster: false,
+					solo: false,
+				},
+				F: {
+					muted: false,
+					volume: 100,
+					sendToMaster: false,
+					solo: false,
+				},
+				G: {
+					muted: false,
+					volume: 100,
+					sendToMaster: false,
+					solo: false,
+				},
+			} as VMixAudioBusesState, // we're parsing a little more, might be useful down the road
 		})
 	})
 

--- a/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmixMock.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/__tests__/vmixMock.ts
@@ -45,6 +45,13 @@ ${inputs?.join('\r\n') ?? defaultInputs}\r\n
 <fullscreen>False</fullscreen>
 <audio>
 <master volume="100" muted="False" meterF1="0.04211706" meterF2="0.04211706" headphonesVolume="74.80521"/>
+<busA volume="100" muted="False" meterF1="0" meterF2="0" solo="False" sendToMaster="False"/>
+<busB volume="78.07491" muted="False" meterF1="0" meterF2="0" solo="False" sendToMaster="False"/>
+<busC volume="100" muted="False" meterF1="0" meterF2="0" solo="False" sendToMaster="False"/>
+<busD volume="100" muted="False" meterF1="0" meterF2="0" solo="False" sendToMaster="False"/>
+<busE volume="100" muted="True" meterF1="0" meterF2="0" solo="False" sendToMaster="False"/>
+<busF volume="100" muted="False" meterF1="0" meterF2="0" solo="False" sendToMaster="False"/>
+<busG volume="100" muted="False" meterF1="0" meterF2="0" solo="False" sendToMaster="False"/>
 </audio>
 </vmix>\r\n`
 }

--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'eventemitter3'
 import { Socket } from 'net'
-import { VMixCommand } from 'timeline-state-resolver-types'
+import { MappingVmixAudioBus, VMixCommand } from 'timeline-state-resolver-types'
 import { VMixStateCommand } from './vMixCommands'
 import { Response, VMixResponseStreamReader } from './vMixResponseStreamReader'
 
@@ -317,16 +317,23 @@ export class VMixCommandSender {
 		return this.sendCommandFunction(`AudioBusOff`, { input, value })
 	}
 
-	public async setBusAudioOn(bus: string): Promise<any> {
-		return this.sendCommandFunction(`Bus${bus}AudioOn`, {})
+	public async setBusAudioOn(bus: MappingVmixAudioBus['index']): Promise<any> {
+		return this.sendCommandFunction(`${this.busLetterToName(bus)}AudioOn`, {})
 	}
 
-	public async setBusAudioOff(bus: string): Promise<any> {
-		return this.sendCommandFunction(`Bus${bus}AudioOff`, {})
+	public async setBusAudioOff(bus: MappingVmixAudioBus['index']): Promise<any> {
+		return this.sendCommandFunction(`${this.busLetterToName(bus)}AudioOff`, {})
 	}
 
-	public async setBusVolume(bus: string, volume: number): Promise<any> {
-		return this.sendCommandFunction(`SetBus${bus}Volume`, { value: Math.min(Math.max(volume, 0), 100) })
+	public async setBusVolume(bus: MappingVmixAudioBus['index'], volume: number): Promise<any> {
+		return this.sendCommandFunction(`Set${this.busLetterToName(bus)}Volume`, {
+			value: Math.min(Math.max(volume, 0), 100),
+		})
+	}
+
+	private busLetterToName(bus: MappingVmixAudioBus['index']): string {
+		if (bus === 'M') return 'Master'
+		return `Bus${bus}`
 	}
 
 	public async setFader(position: number): Promise<any> {

--- a/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/connection.ts
@@ -179,6 +179,12 @@ export class VMixCommandSender {
 				return this.setAudioBusOn(command.input, command.value)
 			case VMixCommand.AUDIO_BUS_OFF:
 				return this.setAudioBusOff(command.input, command.value)
+			case VMixCommand.BUS_AUDIO_ON:
+				return this.setBusAudioOn(command.bus)
+			case VMixCommand.BUS_AUDIO_OFF:
+				return this.setBusAudioOff(command.bus)
+			case VMixCommand.BUS_VOLUME:
+				return this.setBusVolume(command.bus, command.value)
 			case VMixCommand.FADER:
 				return this.setFader(command.value)
 			case VMixCommand.START_RECORDING:
@@ -309,6 +315,18 @@ export class VMixCommandSender {
 
 	public async setAudioBusOff(input: number | string, value: string): Promise<any> {
 		return this.sendCommandFunction(`AudioBusOff`, { input, value })
+	}
+
+	public async setBusAudioOn(bus: string): Promise<any> {
+		return this.sendCommandFunction(`Bus${bus}AudioOn`, {})
+	}
+
+	public async setBusAudioOff(bus: string): Promise<any> {
+		return this.sendCommandFunction(`Bus${bus}AudioOff`, {})
+	}
+
+	public async setBusVolume(bus: string, volume: number): Promise<any> {
+		return this.sendCommandFunction(`SetBus${bus}Volume`, { value: Math.min(Math.max(volume, 0), 100) })
 	}
 
 	public async setFader(position: number): Promise<any> {

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -101,11 +101,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 			this.addToQueue(commands, this.getCurrentTime())
 		)
 
-		this._timelineStateConverter = new VMixTimelineStateConverter(
-			() => this._stateDiffer.getDefaultState(),
-			(inputNumber) => this._stateDiffer.getDefaultInputState(inputNumber),
-			(inputNumber) => this._stateDiffer.getDefaultInputAudioState(inputNumber)
-		)
+		this._timelineStateConverter = new VMixTimelineStateConverter(this._stateDiffer)
 
 		this._xmlStateParser = new VMixXmlStateParser()
 		this._stateSynchronizer = new VMixStateSynchronizer()

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
@@ -52,6 +52,19 @@ export interface VMixStateCommandAudioBusOff extends VMixStateCommandBase {
 	input: number | string
 	value: string
 }
+export interface VMixStateCommandBusAudioOn extends VMixStateCommandBase {
+	command: VMixCommand.BUS_AUDIO_ON
+	bus: string
+}
+export interface VMixStateCommandBusAudioOff extends VMixStateCommandBase {
+	command: VMixCommand.BUS_AUDIO_OFF
+	bus: string
+}
+export interface VMixStateCommandBusVolume extends VMixStateCommandBase {
+	command: VMixCommand.BUS_VOLUME
+	bus: string
+	value: number
+}
 export interface VMixStateCommandFader extends VMixStateCommandBase {
 	command: VMixCommand.FADER
 	value: number
@@ -236,6 +249,9 @@ export type VMixStateCommand =
 	| VMixStateCommandAudioAutoOff
 	| VMixStateCommandAudioBusOn
 	| VMixStateCommandAudioBusOff
+	| VMixStateCommandBusAudioOn
+	| VMixStateCommandBusAudioOff
+	| VMixStateCommandBusVolume
 	| VMixStateCommandFader
 	| VMixStateCommandSetZoom
 	| VMixStateCommandSetPanX

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixCommands.ts
@@ -1,4 +1,4 @@
-import { VMixCommand } from 'timeline-state-resolver-types'
+import { MappingVmixAudioBus, VMixCommand } from 'timeline-state-resolver-types'
 
 export interface VMixStateCommandBase {
 	command: VMixCommand
@@ -54,15 +54,15 @@ export interface VMixStateCommandAudioBusOff extends VMixStateCommandBase {
 }
 export interface VMixStateCommandBusAudioOn extends VMixStateCommandBase {
 	command: VMixCommand.BUS_AUDIO_ON
-	bus: string
+	bus: MappingVmixAudioBus['index']
 }
 export interface VMixStateCommandBusAudioOff extends VMixStateCommandBase {
 	command: VMixCommand.BUS_AUDIO_OFF
-	bus: string
+	bus: MappingVmixAudioBus['index']
 }
 export interface VMixStateCommandBusVolume extends VMixStateCommandBase {
 	command: VMixCommand.BUS_VOLUME
-	bus: string
+	bus: MappingVmixAudioBus['index']
 	value: number
 }
 export interface VMixStateCommandFader extends VMixStateCommandBase {

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixStateDiffer.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixStateDiffer.ts
@@ -8,6 +8,7 @@ import {
 	VMixLayer,
 	VMixText,
 	VMixImages,
+	MappingVmixAudioBus,
 } from 'timeline-state-resolver-types'
 import { CommandContext, VMixStateCommandWithContext } from './vMixCommands'
 import _ = require('underscore')
@@ -840,6 +841,7 @@ export class VMixStateDiffer implements VMixDefaultStateFactory {
 	): Array<VMixStateCommandWithContext> {
 		const commands: Array<VMixStateCommandWithContext> = []
 		for (const [index, bus] of Object.entries<VMixAudioBusBase | undefined>(newVMixState.audioBuses)) {
+			const busName = index as MappingVmixAudioBus['index']
 			if (!bus) continue
 			const oldBus = oldVMixState.audioBuses[index as keyof VMixAudioBusesState]
 			// probably makes sense to do this before updating volume:
@@ -847,7 +849,7 @@ export class VMixStateDiffer implements VMixDefaultStateFactory {
 				commands.push({
 					command: {
 						command: VMixCommand.BUS_AUDIO_OFF,
-						bus: index,
+						bus: busName,
 					},
 					context: CommandContext.None,
 					timelineId: '',
@@ -857,7 +859,7 @@ export class VMixStateDiffer implements VMixDefaultStateFactory {
 				commands.push({
 					command: {
 						command: VMixCommand.BUS_VOLUME,
-						bus: index,
+						bus: busName,
 						value: bus.volume,
 					},
 					context: CommandContext.None,
@@ -869,7 +871,7 @@ export class VMixStateDiffer implements VMixDefaultStateFactory {
 				commands.push({
 					command: {
 						command: VMixCommand.BUS_AUDIO_ON,
-						bus: index,
+						bus: busName,
 					},
 					context: CommandContext.None,
 					timelineId: '',

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixStateDiffer.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixStateDiffer.ts
@@ -44,7 +44,7 @@ export interface VMixState {
 	playlist: boolean
 	multiCorder: boolean
 	fullscreen: boolean
-	audio: VMixAudioChannel[]
+	audioBuses: VMixAudioBusesState
 }
 
 interface VMixOutputsState {
@@ -57,6 +57,10 @@ interface VMixOutputsState {
 	Fullscreen: VMixOutput | undefined
 	Fullscreen2: VMixOutput | undefined
 }
+
+export type VMixAudioBusesState = {
+	M: VMixAudioBusBase | undefined
+} & Record<'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G', VMixAudioBusBase | undefined>
 
 export interface VMixMix {
 	number: number
@@ -107,11 +111,17 @@ export interface VMixOverlay {
 	input: string | number | undefined
 }
 
-export interface VMixAudioChannel {
+export interface VMixAudioBusBase {
 	volume: number
 	muted: boolean
-	meterF1: number
-	meterF2: number
+}
+
+export interface VMixAudioRegularBus extends VMixAudioBusBase {
+	solo: boolean
+	sendToMaster: boolean
+}
+
+export interface VMixAudioMasterBus extends VMixAudioBusBase {
 	headphonesVolume: number
 }
 
@@ -120,7 +130,14 @@ interface PreAndPostTransitionCommands {
 	postTransitionCommands: Array<VMixStateCommandWithContext>
 }
 
-export class VMixStateDiffer {
+export interface VMixDefaultStateFactory {
+	getDefaultState: () => VMixStateExtended
+	getDefaultInputState: (inputIndex: number | string | undefined) => VMixInput
+	getDefaultInputAudioState: (inputIndex: number | string | undefined) => VMixInputAudio
+	getDefaultAudioBusState: () => VMixAudioBusBase
+}
+
+export class VMixStateDiffer implements VMixDefaultStateFactory {
 	private inputHandler: VMixInputHandler
 
 	constructor(
@@ -142,6 +159,7 @@ export class VMixStateDiffer {
 		commands = commands.concat(this._resolveOverlaysState(oldVMixState, newVMixState))
 		commands = commands.concat(inputCommands.postTransitionCommands)
 		commands = commands.concat(this._resolveInputsAudioState(oldVMixState, newVMixState))
+		commands = commands.concat(this._resolveAudioBusesState(oldVMixState.reportedState, newVMixState.reportedState))
 		commands = commands.concat(this._resolveRecordingState(oldVMixState.reportedState, newVMixState.reportedState))
 		commands = commands.concat(this._resolveStreamingState(oldVMixState.reportedState, newVMixState.reportedState))
 		commands = commands.concat(this._resolveExternalState(oldVMixState.reportedState, newVMixState.reportedState))
@@ -173,7 +191,16 @@ export class VMixStateDiffer {
 				playlist: false,
 				multiCorder: false,
 				fullscreen: false,
-				audio: [],
+				audioBuses: {
+					M: undefined,
+					A: undefined,
+					B: undefined,
+					C: undefined,
+					D: undefined,
+					E: undefined,
+					F: undefined,
+					G: undefined,
+				},
 			},
 			outputs: {
 				'2': undefined,
@@ -213,6 +240,13 @@ export class VMixStateDiffer {
 			fade: 0,
 			audioBuses: 'M',
 			audioAuto: true,
+		}
+	}
+
+	getDefaultAudioBusState(): VMixAudioBusBase {
+		return {
+			muted: true,
+			volume: 100,
 		}
 	}
 
@@ -797,6 +831,51 @@ export class VMixStateDiffer {
 				this.inputHandler.removeInput(time, input)
 			}
 		)
+		return commands
+	}
+
+	private _resolveAudioBusesState(
+		oldVMixState: VMixState,
+		newVMixState: VMixState
+	): Array<VMixStateCommandWithContext> {
+		const commands: Array<VMixStateCommandWithContext> = []
+		for (const [index, bus] of Object.entries<VMixAudioBusBase | undefined>(newVMixState.audioBuses)) {
+			if (!bus) continue
+			const oldBus = oldVMixState.audioBuses[index as keyof VMixAudioBusesState]
+			// probably makes sense to do this before updating volume:
+			if (bus.muted && oldBus?.muted !== bus.muted) {
+				commands.push({
+					command: {
+						command: VMixCommand.BUS_AUDIO_OFF,
+						bus: index,
+					},
+					context: CommandContext.None,
+					timelineId: '',
+				})
+			}
+			if (oldBus?.volume !== bus.volume) {
+				commands.push({
+					command: {
+						command: VMixCommand.BUS_VOLUME,
+						bus: index,
+						value: bus.volume,
+					},
+					context: CommandContext.None,
+					timelineId: '',
+				})
+			}
+			// probably makes sense to do this after updating volume:
+			if (!bus.muted && oldBus?.muted !== bus.muted) {
+				commands.push({
+					command: {
+						command: VMixCommand.BUS_AUDIO_ON,
+						bus: index,
+					},
+					context: CommandContext.None,
+					timelineId: '',
+				})
+			}
+		}
 		return commands
 	}
 

--- a/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/vMixTimelineStateConverter.ts
@@ -12,7 +12,14 @@ import {
 	VMixTransition,
 	VMixTransitionType,
 } from 'timeline-state-resolver-types'
-import { TSR_INPUT_PREFIX, VMixInput, VMixInputAudio, VMixState, VMixStateExtended } from './vMixStateDiffer'
+import {
+	TSR_INPUT_PREFIX,
+	VMixDefaultStateFactory,
+	VMixInput,
+	VMixInputAudio,
+	VMixState,
+	VMixStateExtended,
+} from './vMixStateDiffer'
 import * as deepMerge from 'deepmerge'
 import _ = require('underscore')
 
@@ -29,6 +36,7 @@ const mappingPriority: { [k in MappingVmixType]: number } = {
 	[MappingVmixType.FadeToBlack]: 9,
 	[MappingVmixType.Fader]: 10,
 	[MappingVmixType.Script]: 11,
+	[MappingVmixType.AudioBus]: 11,
 }
 
 export type MappingsVmix = Mappings<SomeMappingVmix>
@@ -37,17 +45,13 @@ export type MappingsVmix = Mappings<SomeMappingVmix>
  * Converts timeline state, to a TSR representation
  */
 export class VMixTimelineStateConverter {
-	constructor(
-		private readonly getDefaultState: () => VMixStateExtended,
-		private readonly getDefaultInputState: (inputIndex: number | string | undefined) => VMixInput,
-		private readonly getDefaultInputAudioState: (inputIndex: number | string | undefined) => VMixInputAudio
-	) {}
+	constructor(private defaultStateFactory: VMixDefaultStateFactory) {}
 
 	getVMixStateFromTimelineState(
 		state: Timeline.TimelineState<TSRTimelineContent>,
 		mappings: MappingsVmix
 	): VMixStateExtended {
-		const deviceState = this._fillStateWithMappingsDefaults(this.getDefaultState(), mappings)
+		const deviceState = this._fillStateWithMappingsDefaults(this.defaultStateFactory.getDefaultState(), mappings)
 
 		// Sort layer based on Mapping type (to make sure audio is after inputs) and Layer name
 		const sortedLayers = _.sortBy(
@@ -180,6 +184,13 @@ export class VMixTimelineStateConverter {
 							deviceState.runningScripts.push(content.name)
 						}
 						break
+					case MappingVmixType.AudioBus:
+						if (content.type === TimelineContentTypeVMix.AUDIO_BUS) {
+							const existingBus = deviceState.reportedState.audioBuses[mapping.options.index]
+							if (!existingBus) break
+							existingBus.muted = content.muted ?? existingBus.muted
+							existingBus.volume = content.volume ?? existingBus.volume
+						}
 				}
 			}
 		})
@@ -205,7 +216,10 @@ export class VMixTimelineStateConverter {
 			inputKey = input.key
 		}
 		if (inputKey) {
-			inputs[inputKey] = deepMerge(inputs[inputKey] ?? this.getDefaultInputState(inputKey), filteredNewInput)
+			inputs[inputKey] = deepMerge(
+				inputs[inputKey] ?? this.defaultStateFactory.getDefaultInputState(inputKey),
+				filteredNewInput
+			)
 			deviceState.inputLayers[layerName] = inputKey as string
 		}
 		return deviceState.reportedState
@@ -226,7 +240,10 @@ export class VMixTimelineStateConverter {
 			inputKey = input.key
 		}
 		if (inputKey) {
-			inputs[inputKey] = deepMerge(inputs[inputKey] ?? this.getDefaultInputAudioState(inputKey), filteredNewInput)
+			inputs[inputKey] = deepMerge(
+				inputs[inputKey] ?? this.defaultStateFactory.getDefaultInputAudioState(inputKey),
+				filteredNewInput
+			)
 		}
 		return deviceState.reportedState
 	}
@@ -268,14 +285,15 @@ export class VMixTimelineStateConverter {
 				}
 				case MappingVmixType.Input:
 					if (mapping.options.index) {
-						state.reportedState.existingInputs[mapping.options.index] = this.getDefaultInputState(mapping.options.index)
+						state.reportedState.existingInputs[mapping.options.index] = this.defaultStateFactory.getDefaultInputState(
+							mapping.options.index
+						)
 					}
 					break
 				case MappingVmixType.AudioChannel:
 					if (mapping.options.index) {
-						state.reportedState.existingInputsAudio[mapping.options.index] = this.getDefaultInputAudioState(
-							mapping.options.index
-						)
+						state.reportedState.existingInputsAudio[mapping.options.index] =
+							this.defaultStateFactory.getDefaultInputAudioState(mapping.options.index)
 					}
 					break
 				case MappingVmixType.Recording:
@@ -295,6 +313,9 @@ export class VMixTimelineStateConverter {
 						number: mapping.options.index,
 						input: undefined,
 					}
+					break
+				case MappingVmixType.AudioBus:
+					state.reportedState.audioBuses[mapping.options.index] = this.defaultStateFactory.getDefaultAudioBusState()
 					break
 			}
 		}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of TV 2 Norge

## Type of Contribution

This is a: 
<!-- (pick one) -->
Feature


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
Not possible to control vMix audio buses themselves (except of routing inputs to them).

## New Behavior
<!--
What is the new behavior?
-->
Support for vMix audio buses (Master, and A through G) is added. Only `mute` and `volume` are supported in this PR.

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
