### PR TITLE
fix: move functions related to TemplateString to TSR-types.

### DIFF
--- a/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -81,5 +81,7 @@ exports[`index imports 1`] = `
   "ViscaOverIPActions",
   "VizMSEActions",
   "VmixActions",
+  "interpolateTemplateString",
+  "interpolateTemplateStringIfNeeded",
 ]
 `;

--- a/packages/timeline-state-resolver-types/src/__tests__/templateString.spec.ts
+++ b/packages/timeline-state-resolver-types/src/__tests__/templateString.spec.ts
@@ -1,4 +1,4 @@
-import { interpolateTemplateString, interpolateTemplateStringIfNeeded } from '../lib'
+import { interpolateTemplateString, interpolateTemplateStringIfNeeded } from '../templateString'
 
 describe('interpolateTemplateString', () => {
 	test('basic input', () => {

--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -49,6 +49,7 @@ export * from './integrations/viscaOverIP'
 
 export * from './device'
 export * from './mapping'
+export * from './templateString'
 
 export { Timeline }
 export * from './mapping'
@@ -174,14 +175,4 @@ export enum ActionExecutionResultCode {
 	Error = 'ERROR',
 	IgnoredNotRelevant = 'IGNORED',
 	Ok = 'OK',
-}
-
-/** This resolves to a string, where parts can be defined by the datastore */
-export interface TemplateString {
-	/** The string template. Example: "http://google.com?q={{searchString}}" */
-	key: string
-	/** Values for the arguments in the key string. Example: { searchString: "TSR" } */
-	args?: {
-		[k: string]: any
-	}
 }

--- a/packages/timeline-state-resolver-types/src/templateString.ts
+++ b/packages/timeline-state-resolver-types/src/templateString.ts
@@ -1,0 +1,31 @@
+/** This resolves to a string, where parts can be defined by the datastore */
+export interface TemplateString {
+	/** The string template. Example: "http://google.com?q={{searchString}}" */
+	key: string
+	/** Values for the arguments in the key string. Example: { searchString: "TSR" } */
+	args?: {
+		[k: string]: any
+	}
+}
+
+/**
+ * Interpolate a translation style string
+ */
+export function interpolateTemplateString(key: string, args: { [key: string]: any } | undefined): string {
+	if (!args || typeof key !== 'string') {
+		return String(key)
+	}
+
+	let interpolated = String(key)
+	for (const placeholder of key.match(/[^{}]+(?=})/g) || []) {
+		const value = args[placeholder] || placeholder
+		interpolated = interpolated.replace(`{{${placeholder}}}`, value)
+	}
+
+	return interpolated
+}
+
+export function interpolateTemplateStringIfNeeded(str: string | TemplateString): string {
+	if (typeof str === 'string') return str
+	return interpolateTemplateString(str.key, str.args)
+}

--- a/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -95,6 +95,8 @@ exports[`index imports 1`] = `
   "VizMSEActions",
   "VizMSEDevice",
   "VmixActions",
+  "interpolateTemplateString",
+  "interpolateTemplateStringIfNeeded",
   "manifest",
 ]
 `;

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -32,6 +32,7 @@ import {
 	Mapping,
 	CasparCGActionExecutionPayload,
 	ListMediaResult,
+	interpolateTemplateStringIfNeeded,
 } from 'timeline-state-resolver-types'
 
 import {
@@ -57,15 +58,7 @@ import { DoOnTime, SendMode } from '../../devices/doOnTime'
 import got from 'got'
 import { InternalTransitionHandler } from '../../devices/transitions/transitionHandler'
 import Debug from 'debug'
-import {
-	actionNotFoundMessage,
-	deepMerge,
-	endTrace,
-	interpolateTemplateStringIfNeeded,
-	literal,
-	startTrace,
-	t,
-} from '../../lib'
+import { actionNotFoundMessage, deepMerge, endTrace, literal, startTrace, t } from '../../lib'
 import { ClsParameters } from 'casparcg-connection/dist/parameters'
 const debug = Debug('timeline-state-resolver:casparcg')
 

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -13,10 +13,11 @@ import {
 	Timeline,
 	TimelineContentTypeHTTP,
 	TimelineContentTypeHTTPParamType,
+	interpolateTemplateStringIfNeeded,
 } from 'timeline-state-resolver-types'
 import _ = require('underscore')
 import got, { OptionsOfTextResponseBody, RequestError } from 'got'
-import { interpolateTemplateStringIfNeeded, t } from '../../lib'
+import { t } from '../../lib'
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent'
 import CacheableLookup from 'cacheable-lookup'
 

--- a/packages/timeline-state-resolver/src/integrations/sofieChef/stateBuilder.ts
+++ b/packages/timeline-state-resolver/src/integrations/sofieChef/stateBuilder.ts
@@ -5,9 +5,9 @@ import {
 	Mapping,
 	SomeMappingSofieChef,
 	DeviceType,
+	interpolateTemplateStringIfNeeded,
 } from 'timeline-state-resolver-types'
 import type { SofieChefState } from '.'
-import { interpolateTemplateStringIfNeeded } from '../../lib'
 
 export function buildSofieChefState(
 	timelineState: Timeline.TimelineState<TSRTimelineContent>,

--- a/packages/timeline-state-resolver/src/lib.ts
+++ b/packages/timeline-state-resolver/src/lib.ts
@@ -8,7 +8,6 @@ import {
 	ActionExecutionResultCode,
 	TimelineDatastoreReferences,
 	ActionExecutionResult,
-	TemplateString,
 } from 'timeline-state-resolver-types'
 import * as _ from 'underscore'
 import { PartialDeep } from 'type-fest'
@@ -281,6 +280,7 @@ export function fillStateFromDatastore(state: Timeline.TimelineState<TSRTimeline
 	return filledState
 }
 
+/** Create a Translatable message */
 export function t(key: string, args?: { [k: string]: any }): ITranslatableMessage {
 	return {
 		key,
@@ -307,26 +307,4 @@ export function actionNotFoundMessage(id: never): ActionExecutionResult<any> {
 
 export function cloneDeep<T>(input: T): T {
 	return klona(input)
-}
-
-/**
- * Interpolate a translation style string
- */
-export function interpolateTemplateString(key: string, args: { [key: string]: any } | undefined): string {
-	if (!args || typeof key !== 'string') {
-		return String(key)
-	}
-
-	let interpolated = String(key)
-	for (const placeholder of key.match(/[^{}]+(?=})/g) || []) {
-		const value = args[placeholder] || placeholder
-		interpolated = interpolated.replace(`{{${placeholder}}}`, value)
-	}
-
-	return interpolated
-}
-
-export function interpolateTemplateStringIfNeeded(str: string | TemplateString): string {
-	if (typeof str === 'string') return str
-	return interpolateTemplateString(str.key, str.args)
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Code improvement 


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

`TemplateString` is exported in TSR-types, and used in TSR-types data. But helper functions (such as `interpolateTemplateString`) that are essential to working with it, is not.

## New Behavior
<!--
What is the new behavior?
-->
The helper functions `interpolateTemplateString` and `interpolateTemplateStringIfNeeded` are moved to TSR-types and now exported.

This is useful for consumers of TSR-types to be able to work with TSR-types data (for example `url: string | TemplateString`) without having to import TSR.



## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
