### PR TITLE
fix: move functions related to Datastore to TSR-types.

### DIFF
--- a/packages/quick-tsr/input/datastore.ts
+++ b/packages/quick-tsr/input/datastore.ts
@@ -1,4 +1,4 @@
-import { Datastore } from 'timeline-state-resolver'
+import { Datastore } from 'timeline-state-resolver-types'
 import { literal } from 'timeline-state-resolver/dist/lib'
 import { TSRInput } from '../src'
 

--- a/packages/quick-tsr/package.json
+++ b/packages/quick-tsr/package.json
@@ -65,6 +65,7 @@
 		"fast-clone": "^1.5.13",
 		"threadedclass": "^1.2.2",
 		"timeline-state-resolver": "9.4.0-release53",
+		"timeline-state-resolver-types": "9.4.0-release53",
 		"tslib": "^2.6.3",
 		"underscore": "^1.13.7"
 	}

--- a/packages/quick-tsr/src/index.ts
+++ b/packages/quick-tsr/src/index.ts
@@ -3,7 +3,7 @@ import * as chokidar from 'chokidar'
 import * as fs from 'fs'
 import * as _ from 'underscore'
 import * as path from 'path'
-import { Mappings, TSRTimeline, DeviceOptionsAny, Datastore } from 'timeline-state-resolver'
+import { Mappings, TSRTimeline, DeviceOptionsAny, Datastore } from 'timeline-state-resolver-types'
 import { TSRHandler } from './tsrHandler'
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const clone = require('fast-clone')

--- a/packages/quick-tsr/src/tsrHandler.ts
+++ b/packages/quick-tsr/src/tsrHandler.ts
@@ -2,18 +2,20 @@ import {
 	Conductor,
 	ConductorOptions,
 	TimelineTriggerTimeResult,
+	SlowSentCommandInfo,
+	SlowFulfilledCommandInfo,
+	CasparCGDevice,
+} from 'timeline-state-resolver'
+import {
 	DeviceOptionsAny,
 	Mappings,
 	TSRTimeline,
 	Datastore,
 	DeviceStatus,
-	SlowSentCommandInfo,
-	SlowFulfilledCommandInfo,
 	DeviceType,
-	CasparCGDevice,
 	CasparCGActions,
 	ActionExecutionResultCode,
-} from 'timeline-state-resolver'
+} from 'timeline-state-resolver-types'
 import { ThreadedClass } from 'threadedclass'
 
 import { TSRSettings } from './index'

--- a/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver-types/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -81,6 +81,7 @@ exports[`index imports 1`] = `
   "ViscaOverIPActions",
   "VizMSEActions",
   "VmixActions",
+  "fillStateFromDatastore",
   "interpolateTemplateString",
   "interpolateTemplateStringIfNeeded",
 ]

--- a/packages/timeline-state-resolver-types/src/datastore.ts
+++ b/packages/timeline-state-resolver-types/src/datastore.ts
@@ -1,0 +1,47 @@
+import {
+	Datastore,
+	Timeline,
+	TimelineDatastoreReferences,
+	TimelineDatastoreReferencesContent,
+	TSRTimelineContent,
+} from '.'
+
+/**
+ * Set a value on an object from a .-delimited path
+ * @param obj The base object
+ * @param path Path of the value to set
+ * @param val The value to set
+ */
+const set = (obj: Record<string, any>, path: string, val: any) => {
+	const p = path.split('.')
+	p.slice(0, -1).reduce((a, b) => (a[b] ? a[b] : (a[b] = {})), obj)[p.slice(-1)[0]] = val
+}
+export function fillStateFromDatastore(state: Timeline.TimelineState<TSRTimelineContent>, datastore: Datastore) {
+	// clone the state so we can freely manipulate it
+	const filledState: typeof state = JSON.parse(JSON.stringify(state))
+
+	Object.values<Timeline.ResolvedTimelineObjectInstance<TSRTimelineContent>>(filledState.layers).forEach(
+		({ content, instance }) => {
+			if ((content as TimelineDatastoreReferencesContent).$references) {
+				Object.entries<TimelineDatastoreReferences[0]>(
+					(content as TimelineDatastoreReferencesContent).$references || {}
+				).forEach(([path, ref]) => {
+					const datastoreVal = datastore[ref.datastoreKey]
+
+					if (datastoreVal !== undefined) {
+						if (ref.overwrite) {
+							// only use the datastore value if it was changed after the tl obj started
+							if ((instance.originalStart || instance.start || 0) <= datastoreVal.modified) {
+								set(content, path, datastoreVal.value)
+							}
+						} else {
+							set(content, path, datastoreVal.value)
+						}
+					}
+				})
+			}
+		}
+	)
+
+	return filledState
+}

--- a/packages/timeline-state-resolver-types/src/datastore.ts
+++ b/packages/timeline-state-resolver-types/src/datastore.ts
@@ -16,7 +16,10 @@ const set = (obj: Record<string, any>, path: string, val: any) => {
 	const p = path.split('.')
 	p.slice(0, -1).reduce((a, b) => (a[b] ? a[b] : (a[b] = {})), obj)[p.slice(-1)[0]] = val
 }
-export function fillStateFromDatastore(state: Timeline.TimelineState<TSRTimelineContent>, datastore: Datastore) {
+export function fillStateFromDatastore(
+	state: Timeline.TimelineState<TSRTimelineContent>,
+	datastore: Datastore
+): Timeline.TimelineState<TSRTimelineContent> {
 	// clone the state so we can freely manipulate it
 	const filledState: typeof state = JSON.parse(JSON.stringify(state))
 

--- a/packages/timeline-state-resolver-types/src/index.ts
+++ b/packages/timeline-state-resolver-types/src/index.ts
@@ -47,6 +47,7 @@ export * from './integrations/telemetrics'
 export * from './integrations/multiOsc'
 export * from './integrations/viscaOverIP'
 
+export * from './datastore'
 export * from './device'
 export * from './mapping'
 export * from './templateString'

--- a/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/timeline-state-resolver/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -95,6 +95,7 @@ exports[`index imports 1`] = `
   "VizMSEActions",
   "VizMSEDevice",
   "VmixActions",
+  "fillStateFromDatastore",
   "interpolateTemplateString",
   "interpolateTemplateStringIfNeeded",
   "manifest",

--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -44,11 +44,12 @@ import {
 	DeviceOptionsViscaOverIP,
 	DeviceOptionsTriCaster,
 	DeviceOptionsSingularLive,
+	fillStateFromDatastore,
 } from 'timeline-state-resolver-types'
 
 import { DoOnTime } from './devices/doOnTime'
 import { AsyncResolver } from './AsyncResolver'
-import { endTrace, fillStateFromDatastore, FinishedTrace, startTrace } from './lib'
+import { endTrace, FinishedTrace, startTrace } from './lib'
 
 import { CommandWithContext } from './devices/device'
 import { DeviceContainer } from './devices/deviceContainer'

--- a/packages/timeline-state-resolver/src/lib.ts
+++ b/packages/timeline-state-resolver/src/lib.ts
@@ -1,14 +1,5 @@
 import { klona } from 'klona'
-import {
-	Datastore,
-	Timeline,
-	TimelineDatastoreReferencesContent,
-	TSRTimelineContent,
-	ITranslatableMessage,
-	ActionExecutionResultCode,
-	TimelineDatastoreReferences,
-	ActionExecutionResult,
-} from 'timeline-state-resolver-types'
+import { ITranslatableMessage, ActionExecutionResultCode, ActionExecutionResult } from 'timeline-state-resolver-types'
 import * as _ from 'underscore'
 import { PartialDeep } from 'type-fest'
 import deepmerge = require('deepmerge')
@@ -238,46 +229,6 @@ export function endTrace(trace: Trace): FinishedTrace {
  */
 export function deferAsync(fn: () => Promise<void>, catcher: (e: unknown) => void): void {
 	fn().catch(catcher)
-}
-
-/**
- * Set a value on an object from a .-delimited path
- * @param obj The base object
- * @param path Path of the value to set
- * @param val The value to set
- */
-const set = (obj: Record<string, any>, path: string, val: any) => {
-	const p = path.split('.')
-	p.slice(0, -1).reduce((a, b) => (a[b] ? a[b] : (a[b] = {})), obj)[p.slice(-1)[0]] = val
-}
-export function fillStateFromDatastore(state: Timeline.TimelineState<TSRTimelineContent>, datastore: Datastore) {
-	// clone the state so we can freely manipulate it
-	const filledState: typeof state = JSON.parse(JSON.stringify(state))
-
-	Object.values<Timeline.ResolvedTimelineObjectInstance<TSRTimelineContent>>(filledState.layers).forEach(
-		({ content, instance }) => {
-			if ((content as TimelineDatastoreReferencesContent).$references) {
-				Object.entries<TimelineDatastoreReferences[0]>(
-					(content as TimelineDatastoreReferencesContent).$references || {}
-				).forEach(([path, ref]) => {
-					const datastoreVal = datastore[ref.datastoreKey]
-
-					if (datastoreVal !== undefined) {
-						if (ref.overwrite) {
-							// only use the datastore value if it was changed after the tl obj started
-							if ((instance.originalStart || instance.start || 0) <= datastoreVal.modified) {
-								set(content, path, datastoreVal.value)
-							}
-						} else {
-							set(content, path, datastoreVal.value)
-						}
-					}
-				})
-			}
-		}
-	)
-
-	return filledState
 }
 
 /** Create a Translatable message */

--- a/yarn.lock
+++ b/yarn.lock
@@ -9857,6 +9857,7 @@ asn1@evs-broadcast/node-asn1:
     fast-clone: ^1.5.13
     threadedclass: ^1.2.2
     timeline-state-resolver: 9.4.0-release53
+    timeline-state-resolver-types: 9.4.0-release53
     tslib: ^2.6.3
     underscore: ^1.13.7
   languageName: unknown


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Code improvement 


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

`Datastore` is exported in TSR-types, and used in TSR-types data. But helper functions (such as `fillStateFromDatastore` used to apply Datastore data onto a state) that are essential to working with it, is not.


## New Behavior
<!--
What is the new behavior?
-->

The helper function `fillStateFromDatastore` are moved to TSR-types and now exported.

This is useful for consumers of TSR-types to be able to work with TSR-types data without having to import TSR.


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
