### PR TITLE
chore: change CommandContext to be a generic instead of using fields typed as any

### DIFF
--- a/packages/timeline-state-resolver/src/devices/device.ts
+++ b/packages/timeline-state-resolver/src/devices/device.ts
@@ -15,7 +15,7 @@ import { EventEmitter } from 'eventemitter3'
 import { CommandReport, DoOnTime, SlowFulfilledCommandInfo, SlowSentCommandInfo } from './doOnTime'
 import { ExpectedPlayoutItem } from '../expectedPlayoutItems'
 import { FinishedTrace, t } from '../lib'
-import { DeviceEvents, CommandWithContext as ServiceCommandWithContext } from '../service/device'
+import { DeviceEvents, CommandWithContext } from '../service/device'
 
 // =================================================================================================
 // =================================================================================================
@@ -40,9 +40,7 @@ export interface DeviceCommandContainer {
 	commands: Array<DeviceCommand>
 }
 
-export type CommandWithContext = ServiceCommandWithContext
-
-export { DeviceStatus, StatusCode }
+export { DeviceStatus, StatusCode, CommandWithContext }
 
 /**
  * These are the old Device events, emitted by the devices and listened to by conductor.
@@ -67,7 +65,7 @@ export type DeviceEventsOLD = {
 	slowFulfilledCommand: [info: SlowFulfilledCommandInfo]
 
 	/** Something went wrong when executing a command  */
-	commandError: [error: Error, context: CommandWithContext]
+	commandError: [error: Error, context: CommandWithContext<any, any>]
 	/** Update a MediaObject  */
 	updateMediaObject: [collectionId: string, docId: string, doc: MediaObject | null]
 	/** Clear a MediaObjects collection */

--- a/packages/timeline-state-resolver/src/integrations/abstract/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/abstract/index.ts
@@ -10,9 +10,7 @@ import {
 } from 'timeline-state-resolver-types'
 import { Device } from '../../service/device'
 
-export interface AbstractCommandWithContext extends CommandWithContext {
-	command: string
-}
+export type AbstractCommandWithContext = CommandWithContext<string, string>
 
 export type DeviceOptionsAbstractInternal = DeviceOptionsAbstract
 

--- a/packages/timeline-state-resolver/src/integrations/atem/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/index.ts
@@ -22,10 +22,7 @@ import { CommandWithContext, Device } from '../../service/device'
 import { AtemStateBuilder } from './stateBuilder'
 import { createDiffOptions } from './diffState'
 
-export interface AtemCommandWithContext extends CommandWithContext {
-	command: AtemCommands.ISerializableCommand[]
-	context: string
-}
+export type AtemCommandWithContext = CommandWithContext<AtemCommands.ISerializableCommand[], string>
 
 type AtemDeviceState = DeviceState
 
@@ -177,7 +174,7 @@ export class AtemDevice extends Device<AtemOptions, AtemDeviceState, AtemCommand
 	}
 
 	async sendCommand({ command, context, timelineObjId }: AtemCommandWithContext): Promise<void> {
-		const cwc: CommandWithContext = {
+		const cwc: AtemCommandWithContext = {
 			context,
 			command,
 			timelineObjId,

--- a/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/casparCG/index.ts
@@ -823,7 +823,7 @@ export class CasparCGDevice extends DeviceWithState<State, DeviceOptionsCasparCG
 			if (this._retryTime) this._retryTimeout = setTimeout(() => this._assertIntendedState(), this._retryTime)
 		}
 
-		const cwc: CommandWithContext = {
+		const cwc: CommandWithContext<string, string> = {
 			context,
 			timelineObjId,
 			command: JSON.stringify(cmd),

--- a/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpSend/index.ts
@@ -23,13 +23,14 @@ import CacheableLookup from 'cacheable-lookup'
 
 export type HttpSendDeviceState = Timeline.TimelineState<TSRTimelineContent>
 
-export interface HttpSendDeviceCommand extends CommandWithContext {
-	command: {
+export type HttpSendDeviceCommand = CommandWithContext<
+	{
 		commandName: 'added' | 'changed' | 'removed' | 'retry' | 'manual'
 		content: HTTPSendCommandContentExt
 		layer: string
-	}
-}
+	},
+	string
+>
 
 export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState, HttpSendDeviceCommand> {
 	/** Setup in init */
@@ -208,11 +209,6 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 			}
 		}
 
-		const cwc: CommandWithContext = {
-			context,
-			command,
-			timelineObjId,
-		}
 		this.context.logger.debug({ context, timelineObjId, command })
 
 		const t = Date.now()
@@ -286,7 +282,11 @@ export class HTTPSendDevice extends Device<HTTPSendOptions, HttpSendDeviceState,
 				`HTTPSend.response error on ${command.content.type} "${command.content.url}" (${context})`,
 				err
 			)
-			this.context.commandError(err, cwc)
+			this.context.commandError(err, {
+				context,
+				command,
+				timelineObjId,
+			})
 
 			if ('code' in err) {
 				const retryCodes = [

--- a/packages/timeline-state-resolver/src/integrations/httpWatcher/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/httpWatcher/index.ts
@@ -10,11 +10,17 @@ import { CommandWithContext, Device } from '../../service/device'
 
 type HTTPWatcherDeviceState = Record<string, never>
 
+type HTTPWatcherCommandWithContext = CommandWithContext<never, never>
+
 /**
  * This is a HTTPWatcherDevice, requests a uri on a regular interval and watches
  * it's response.
  */
-export class HTTPWatcherDevice extends Device<HTTPWatcherOptions, HTTPWatcherDeviceState, CommandWithContext> {
+export class HTTPWatcherDevice extends Device<
+	HTTPWatcherOptions,
+	HTTPWatcherDeviceState,
+	HTTPWatcherCommandWithContext
+> {
 	readonly actions: Record<string, (id: string, payload?: Record<string, any>) => Promise<ActionExecutionResult>> = {}
 
 	private uri?: string
@@ -127,7 +133,7 @@ export class HTTPWatcherDevice extends Device<HTTPWatcherOptions, HTTPWatcherDev
 		// Noop
 		return {}
 	}
-	diffStates(): Array<CommandWithContext> {
+	diffStates(): Array<HTTPWatcherCommandWithContext> {
 		// Noop
 		return []
 	}

--- a/packages/timeline-state-resolver/src/integrations/hyperdeck/diffState.ts
+++ b/packages/timeline-state-resolver/src/integrations/hyperdeck/diffState.ts
@@ -2,9 +2,15 @@ import { Commands as HyperdeckCommands, TransportStatus } from 'hyperdeck-connec
 import { CommandWithContext } from '../..'
 import type { HyperdeckDeviceState } from './stateBuilder'
 
-export interface HyperdeckCommandWithContext extends CommandWithContext {
-	command: HyperdeckCommands.AbstractCommand<any>
+export interface HyperdeckCommandContext {
+	oldState: HyperdeckDeviceState['transport'] | HyperdeckDeviceState['notify'] | undefined
+	newState: HyperdeckDeviceState['transport'] | HyperdeckDeviceState['notify']
 }
+
+export type HyperdeckCommandWithContext = CommandWithContext<
+	HyperdeckCommands.AbstractCommand<any>,
+	HyperdeckCommandContext
+>
 
 function diffHyperdeckNotifyStates(
 	oldHyperdeckState: HyperdeckDeviceState | undefined,

--- a/packages/timeline-state-resolver/src/integrations/hyperdeck/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/hyperdeck/index.ts
@@ -1,4 +1,4 @@
-import { CommandWithContext, DeviceStatus, StatusCode } from '../../devices/device'
+import { DeviceStatus, StatusCode } from '../../devices/device'
 import {
 	HyperdeckOptions,
 	Mappings,
@@ -203,13 +203,9 @@ export class HyperdeckDevice extends Device<HyperdeckOptions, HyperdeckDeviceSta
 		})
 	}
 
-	async sendCommand({ command, context, timelineObjId }: HyperdeckCommandWithContext): Promise<void> {
-		const cwc: CommandWithContext = {
-			context,
-			command,
-			timelineObjId,
-		}
+	async sendCommand(cwc: HyperdeckCommandWithContext): Promise<void> {
 		this.context.logger.debug(cwc)
+		const { command } = cwc
 
 		// TODO: is this a good idea?
 		// Track what we expect the TransportStatus to be, only Commands we may send need to be considered

--- a/packages/timeline-state-resolver/src/integrations/lawo/diff.ts
+++ b/packages/timeline-state-resolver/src/integrations/lawo/diff.ts
@@ -4,10 +4,7 @@ import { Model as EmberModel } from 'emberplus-connection'
 import { literal } from '../../lib'
 import { CommandWithContext } from '../..'
 
-export interface LawoCommandWithContext extends CommandWithContext {
-	command: LawoCommand
-	context: string
-}
+export type LawoCommandWithContext = CommandWithContext<LawoCommand, string>
 
 export enum LawoCommandType {
 	FaderRamp = 'FaderRamp',

--- a/packages/timeline-state-resolver/src/integrations/multiOsc/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/multiOsc/index.ts
@@ -34,9 +34,7 @@ interface OSCDeviceStateContent extends OSCMessageCommandContent {
 	fromTlObject: string
 }
 
-export interface MultiOscCommandWithContext extends CommandWithContext {
-	command: OSCDeviceStateContent
-}
+export type MultiOscCommandWithContext = CommandWithContext<OSCDeviceStateContent, string>
 
 /**
  * This is a generic wrapper for any osc-enabled device.

--- a/packages/timeline-state-resolver/src/integrations/osc/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/osc/index.ts
@@ -27,9 +27,7 @@ interface OSCDeviceStateContent extends OSCMessageCommandContent {
 	fromTlObject: string
 }
 
-export interface OscCommandWithContext extends CommandWithContext {
-	command: OSCDeviceStateContent
-}
+export type OscCommandWithContext = CommandWithContext<OSCDeviceStateContent, string>
 
 export class OscDevice extends Device<OSCOptions, OscDeviceState, OscCommandWithContext> {
 	/** Setup in init */
@@ -154,13 +152,9 @@ export class OscDevice extends Device<OSCOptions, OscDeviceState, OscCommandWith
 		})
 		return commands
 	}
-	async sendCommand({ command, context, timelineObjId }: OscCommandWithContext): Promise<any> {
-		const cwc: CommandWithContext = {
-			context: context,
-			command: command,
-			timelineObjId,
-		}
+	async sendCommand(cwc: OscCommandWithContext): Promise<any> {
 		this.context.logger.debug(cwc)
+		const { command } = cwc
 		debug(command)
 
 		try {

--- a/packages/timeline-state-resolver/src/integrations/panasonicPTZ/diff.ts
+++ b/packages/timeline-state-resolver/src/integrations/panasonicPTZ/diff.ts
@@ -17,9 +17,7 @@ export interface PanasonicPtzCommand {
 	zoomSpeed?: number // -1 is full speed WIDE, +1 is full speed TELE, 0 is stationary
 	zoom?: number // 0 is WIDE, 1 is TELE
 }
-export interface PanasonicPtzCommandWithContext extends CommandWithContext {
-	command: PanasonicPtzCommand
-}
+export type PanasonicPtzCommandWithContext = CommandWithContext<PanasonicPtzCommand, string>
 
 export function diffStates(
 	oldPtzState: PanasonicPtzState,

--- a/packages/timeline-state-resolver/src/integrations/pharos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/pharos/index.ts
@@ -11,9 +11,7 @@ import { Pharos } from './connection'
 import { Device, CommandWithContext, DeviceContextAPI } from '../../service/device'
 import { diffStates } from './diffStates'
 
-export interface PharosCommandWithContext extends CommandWithContext {
-	command: CommandContent
-}
+export type PharosCommandWithContext = CommandWithContext<CommandContent, string>
 export type PharosState = Timeline.StateInTime<TSRTimelineContent>
 
 interface CommandContent {
@@ -108,19 +106,14 @@ export class PharosDevice extends Device<PharosOptions, PharosState, PharosComma
 		return diffStates(oldPharosState, newPharosState, mappings)
 	}
 
-	async sendCommand({ command, context, timelineObjId }: PharosCommandWithContext): Promise<void> {
-		const cwc: CommandWithContext = {
-			context,
-			command,
-			timelineObjId,
-		}
+	async sendCommand(cwc: PharosCommandWithContext): Promise<void> {
 		this.context.logger.debug(cwc)
 
 		// Skip attempting send if not connected
 		if (!this.connected) return
 
 		try {
-			await command.fcn(this._pharos)
+			await cwc.command.fcn(this._pharos)
 		} catch (error: any) {
 			this.context.commandError(error, cwc)
 		}

--- a/packages/timeline-state-resolver/src/integrations/quantel/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/quantel/index.ts
@@ -28,10 +28,7 @@ interface OSCDeviceStateContent extends OSCMessageCommandContent {
 	fromTlObject: string
 }
 
-export interface QuantelCommandWithContext extends CommandWithContext {
-	command: QuantelCommand
-	context: string
-}
+export type QuantelCommandWithContext = CommandWithContext<QuantelCommand, string>
 
 export class QuantelDevice extends Device<QuantelOptions, QuantelState, QuantelCommandWithContext> {
 	/** Setup in init */
@@ -127,13 +124,9 @@ export class QuantelDevice extends Device<QuantelOptions, QuantelState, QuantelC
 
 		return diffStates(oldState, newState, currentTime)
 	}
-	async sendCommand({ command, context, timelineObjId }: QuantelCommandWithContext): Promise<any> {
-		const cwc: CommandWithContext = {
-			context: context,
-			command: command,
-			timelineObjId: timelineObjId,
-		}
+	async sendCommand(cwc: QuantelCommandWithContext): Promise<any> {
 		this.context.logger.debug(cwc)
+		const { command } = cwc
 		debug(command)
 
 		try {

--- a/packages/timeline-state-resolver/src/integrations/shotoku/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/shotoku/index.ts
@@ -25,9 +25,7 @@ interface ShotokuSequence {
 	shots: TimelineContentShotokuSequence['shots']
 }
 
-export interface ShotokuCommandWithContext extends CommandWithContext {
-	command: ShotokuCommand // todo
-}
+export type ShotokuCommandWithContext = CommandWithContext<ShotokuCommand, string>
 
 export class ShotokuDevice extends Device<ShotokuOptions, ShotokuDeviceState, ShotokuCommandWithContext> {
 	private readonly _shotoku = new ShotokuAPI()
@@ -146,17 +144,17 @@ export class ShotokuDevice extends Device<ShotokuOptions, ShotokuDeviceState, Sh
 
 		return commands
 	}
-	async sendCommand({ command, context, timelineObjId }: ShotokuCommandWithContext): Promise<void> {
-		this.context.logger.debug({ command, context, timelineObjId })
+	async sendCommand(cwc: ShotokuCommandWithContext): Promise<void> {
+		this.context.logger.debug(cwc)
 
 		try {
 			if (this._shotoku.connected) {
-				await this._shotoku.executeCommand(command)
+				await this._shotoku.executeCommand(cwc.command)
 			}
 
 			return
 		} catch (e) {
-			this.context.commandError(e as Error, { command, context, timelineObjId })
+			this.context.commandError(e as Error, cwc)
 			return
 		}
 	}

--- a/packages/timeline-state-resolver/src/integrations/singularLive/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/singularLive/index.ts
@@ -26,9 +26,7 @@ export interface SingularLiveCommandContent {
 	subCompositionName: string
 }
 
-export interface SingularLiveCommandContext extends CommandWithContext {
-	command: Command
-}
+export type SingularLiveCommandContext = CommandWithContext<Command, string>
 
 interface Command {
 	commandName: 'added' | 'changed' | 'removed'
@@ -202,13 +200,9 @@ export class SingularLiveDevice extends Device<SingularLiveOptions, SingularLive
 			.sort((a, b) => a.command.layer.localeCompare(b.command.layer))
 	}
 
-	async sendCommand({ command, context, timelineObjId }: SingularLiveCommandContext): Promise<any> {
-		const cwc: CommandWithContext = {
-			context,
-			command,
-			timelineObjId,
-		}
+	async sendCommand(cwc: SingularLiveCommandContext): Promise<any> {
 		this.context.logger.debug(cwc)
+		const { command, context } = cwc
 
 		const url = SINGULAR_LIVE_API + this._accessToken + '/control'
 

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -34,9 +34,7 @@ export interface DeviceOptionsSisyfosInternal extends DeviceOptionsSisyfos {
 	commandReceiver?: CommandReceiver
 }
 export type CommandReceiver = (time: number, cmd: SisyfosCommand, context: any, timelineObjId: string) => Promise<any>
-interface Command extends CommandWithContext {
-	command: SisyfosCommand
-}
+type Command = CommandWithContext<SisyfosCommand, string>
 
 /**
  * This is a generic wrapper for any osc-enabled device.
@@ -699,7 +697,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 		context: string,
 		timelineObjId: string
 	): Promise<any> {
-		const cwc: CommandWithContext = {
+		const cwc: CommandWithContext<any, any> = {
 			context,
 			command: cmd,
 			timelineObjId,

--- a/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sofieChef/index.ts
@@ -26,9 +26,7 @@ import { CommandWithContext, Device } from '../../service/device'
 import { diffStates } from './diffStates'
 import { buildSofieChefState } from './stateBuilder'
 
-export interface SofieChefCommandWithContext extends CommandWithContext {
-	command: ReceiveWSMessageAny
-}
+export type SofieChefCommandWithContext = CommandWithContext<ReceiveWSMessageAny, string>
 export interface SofieChefState {
 	windows: {
 		[windowId: string]: {
@@ -247,18 +245,13 @@ export class SofieChefDevice extends Device<SofieChefOptions, SofieChefState, So
 		return diffStates(oldSofieChefState, newSofieChefState, mappings)
 	}
 
-	public async sendCommand({ command, context, timelineObjId }: SofieChefCommandWithContext): Promise<any> {
+	public async sendCommand(cwc: SofieChefCommandWithContext): Promise<any> {
 		// emit the command to debug:
-		const cwc: CommandWithContext = {
-			context,
-			command,
-			timelineObjId,
-		}
 		this.context.logger.debug(cwc)
 
 		// execute the command here
 		try {
-			await this._sendMessage(command)
+			await this._sendMessage(cwc.command)
 		} catch (e) {
 			this.context.commandError(e as Error, cwc)
 		}

--- a/packages/timeline-state-resolver/src/integrations/tcpSend/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/tcpSend/index.ts
@@ -16,13 +16,14 @@ import { TcpConnection } from './tcpConnection'
 
 export type TcpSendDeviceState = Timeline.TimelineState<TSRTimelineContent>
 
-export interface TcpSendDeviceCommand extends CommandWithContext {
-	command: {
+export type TcpSendDeviceCommand = CommandWithContext<
+	{
 		commandName: 'added' | 'changed' | 'removed' | 'manual'
 		content: TcpSendCommandContent
 		layer: string
-	}
-}
+	},
+	string
+>
 export class TcpSendDevice extends Device<TCPSendOptions, TcpSendDeviceState, TcpSendDeviceCommand> {
 	private activeLayers = new Map<string, string>()
 	private _terminated = false

--- a/packages/timeline-state-resolver/src/integrations/telemetrics/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/telemetrics/index.ts
@@ -19,9 +19,7 @@ interface TelemetricsState {
 	presetShotIdentifiers: number[]
 }
 
-interface TelemetricsCommandWithContext extends CommandWithContext {
-	command: { presetShotIdentifier: number }
-}
+type TelemetricsCommandWithContext = CommandWithContext<{ presetShotIdentifier: number }, string>
 
 /**
  * Connects to a Telemetrics Device on port 5000 using a TCP socket.
@@ -102,18 +100,13 @@ export class TelemetricsDevice extends Device<TelemetricsOptions, TelemetricsSta
 		return newTelemetricsState
 	}
 
-	async sendCommand({ command, context, timelineObjId }: TelemetricsCommandWithContext): Promise<void> {
-		const cwc: CommandWithContext = {
-			context,
-			command,
-			timelineObjId,
-		}
+	async sendCommand(cwc: TelemetricsCommandWithContext): Promise<void> {
 		this.context.logger.debug(cwc)
 
 		// Skip attempting send if not connected
 		if (!this.socket) return
 
-		const commandStr = `${TELEMETRICS_COMMAND_PREFIX}${command.presetShotIdentifier}\r`
+		const commandStr = `${TELEMETRICS_COMMAND_PREFIX}${cwc.command.presetShotIdentifier}\r`
 		this.socket.write(commandStr)
 	}
 

--- a/packages/timeline-state-resolver/src/integrations/tricaster/triCasterCommands.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/triCasterCommands.ts
@@ -171,8 +171,7 @@ export type TriCasterGenericCommandName<T> = T extends boolean
 	? TriCasterGenericNumberCommand['name']
 	: never
 
-export interface TriCasterCommandWithContext extends CommandWithContext {
-	command: TriCasterCommand
+export interface TriCasterCommandWithContext extends CommandWithContext<TriCasterCommand, string> {
 	temporalPriority: number
 }
 

--- a/packages/timeline-state-resolver/src/integrations/viscaOverIP/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/viscaOverIP/index.ts
@@ -33,9 +33,7 @@ import { ViscaValueConverter } from './connection/lib/ViscaValueConverter'
 
 export type ViscaDeviceState = Timeline.TimelineState<TSRTimelineContent>
 
-export interface ViscaDeviceCommand extends CommandWithContext {
-	command: {}
-}
+export type ViscaDeviceCommand = CommandWithContext<{}, string>
 
 export class ViscaOverIpDevice extends Device<ViscaOverIPOptions, ViscaDeviceState, ViscaDeviceCommand> {
 	protected _terminated = false

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
@@ -942,7 +942,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 		context: string,
 		timelineObjId: string
 	): Promise<any> {
-		const cwc: CommandWithContext = {
+		const cwc: CommandWithContext<any, any> = {
 			context: context,
 			timelineObjId: timelineObjId,
 			command: cmd,

--- a/packages/timeline-state-resolver/src/integrations/vmix/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vmix/index.ts
@@ -433,7 +433,7 @@ export class VMixDevice extends DeviceWithState<VMixStateExtended, DeviceOptions
 		this._expectingPolledState = false
 		this._pollingTimer?.postponeNextTick(BACKOFF_VMIX_POLL_INTERVAL)
 
-		const cwc: CommandWithContext = {
+		const cwc: CommandWithContext<any, any> = {
 			context: context,
 			command: cmd,
 			timelineObjId: timelineObjId,

--- a/packages/timeline-state-resolver/src/integrations/websocketClient/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/websocketClient/index.ts
@@ -14,13 +14,13 @@ import { WebSocketConnection } from './connection'
 import { WebsocketClientActions } from 'timeline-state-resolver-types'
 
 /** this is not an extends but an implementation of the CommandWithContext */
-export interface WebSocketCommand extends CommandWithContext {
-	command: {
+export type WebSocketCommand = CommandWithContext<
+	{
 		type: TimelineContentTypeWebSocketClient
 		message: string
-	}
-	context: string
-}
+	},
+	string
+>
 export type WebSocketClientDeviceState = Timeline.TimelineState<TSRTimelineContent>
 
 export class WebSocketClientDevice extends Device<

--- a/packages/timeline-state-resolver/src/service/DeviceInstance.ts
+++ b/packages/timeline-state-resolver/src/service/DeviceInstance.ts
@@ -37,8 +37,8 @@ export interface DeviceInstanceEvents extends Omit<DeviceEvents, 'connectionChan
  * Top level container for setting up and interacting with any device integrations
  */
 export class DeviceInstanceWrapper extends EventEmitter<DeviceInstanceEvents> {
-	private _device: Device<any, DeviceState, CommandWithContext>
-	private _stateHandler: StateHandler<DeviceState, CommandWithContext>
+	private _device: Device<any, DeviceState, CommandWithContext<any, any>>
+	private _stateHandler: StateHandler<DeviceState, CommandWithContext<any, any>>
 
 	private _deviceId: string
 	private _deviceType: DeviceType
@@ -247,7 +247,7 @@ export class DeviceInstanceWrapper extends EventEmitter<DeviceInstanceEvents> {
 				this.emit('resetResolver')
 			},
 
-			commandError: (error: Error, context: CommandWithContext) => {
+			commandError: (error: Error, context: CommandWithContext<any, any>) => {
 				this.emit('commandError', error, context)
 			},
 			updateMediaObject: (collectionId: string, docId: string, doc: MediaObject | null) => {

--- a/packages/timeline-state-resolver/src/service/commandExecutor.ts
+++ b/packages/timeline-state-resolver/src/service/commandExecutor.ts
@@ -5,7 +5,7 @@ import { StateHandlerContext } from './stateHandler'
 
 const wait = async (t: number) => new Promise<void>((r) => setTimeout(() => r(), t))
 
-export class CommandExecutor<DeviceState, Command extends CommandWithContext> {
+export class CommandExecutor<DeviceState, Command extends CommandWithContext<any, any>> {
 	constructor(
 		private logger: StateHandlerContext['logger'],
 		private mode: 'salvo' | 'sequential',

--- a/packages/timeline-state-resolver/src/service/device.ts
+++ b/packages/timeline-state-resolver/src/service/device.ts
@@ -9,24 +9,22 @@ import {
 	MediaObject,
 } from 'timeline-state-resolver-types'
 
-type CommandContext = any
-
 /**
- * The intended usage of this is to be extended with a device specific type.$
+ * The intended usage of this is for each device to define an alias with the generic types provided.
  * Like so:
- * export interface MyDeviceCommand extends CommandWithContext {
- *   command: { myCommandProps }
- *   context: string
+ * export interface MyDeviceCommand {
+ *   // device specific properties here
  * }
+ * export type MyDeviceCommandWithContext = CommandWithContext<MyDeviceCommand, string>
  */
-export type CommandWithContext = {
+export type CommandWithContext<TCommand, TContext> = {
 	/** Device specific command (to be defined by the device itself) */
-	command: any
+	command: TCommand
 	/**
 	 * The context is provided for logging / troubleshooting reasons.
 	 * It should contain some kind of explanation as to WHY a command was created (like a reference, path etc.)
 	 */
-	context: CommandContext
+	context: TContext
 	/** ID of the timeline-object that the command originated from */
 	timelineObjId: string
 	/** this command is to be executed x ms _before_ the scheduled time */
@@ -38,7 +36,7 @@ export type CommandWithContext = {
 /**
  * API for use by the DeviceInstance to be able to use a device
  */
-export abstract class Device<DeviceOptions, DeviceState, Command extends CommandWithContext>
+export abstract class Device<DeviceOptions, DeviceState, Command extends CommandWithContext<any, any>>
 	implements BaseDeviceAPI<DeviceState, Command>
 {
 	constructor(protected context: DeviceContextAPI<DeviceState>) {
@@ -88,7 +86,7 @@ export abstract class Device<DeviceOptions, DeviceState, Command extends Command
 /**
  * Minimal API for the StateHandler to be able to use a device
  */
-export interface BaseDeviceAPI<DeviceState, Command extends CommandWithContext> {
+export interface BaseDeviceAPI<DeviceState, Command extends CommandWithContext<any, any>> {
 	/**
 	 * This method takes in a Timeline State that describes a point
 	 * in time on the timeline and converts it into a "device state" that
@@ -147,7 +145,7 @@ export interface DeviceEvents {
 	commandReport: [commandReport: CommandReport]
 
 	/** Something went wrong when executing a command  */
-	commandError: [error: Error, context: CommandWithContext]
+	commandError: [error: Error, context: CommandWithContext<any, any>]
 	/** Update a MediaObject  */
 	updateMediaObject: [collectionId: string, docId: string, doc: MediaObject | null]
 	/** Clear a MediaObjects collection */
@@ -184,7 +182,7 @@ export interface DeviceContextAPI<DeviceState> {
 	resetResolver: () => void
 
 	/** Something went wrong when executing a command  */
-	commandError: (error: Error, context: CommandWithContext) => void
+	commandError: (error: Error, context: CommandWithContext<any, any>) => void
 	/** Update a MediaObject  */
 	updateMediaObject: (collectionId: string, docId: string, doc: MediaObject | null) => void
 	/** Clear a MediaObjects collection */

--- a/packages/timeline-state-resolver/src/service/stateHandler.ts
+++ b/packages/timeline-state-resolver/src/service/stateHandler.ts
@@ -4,7 +4,7 @@ import { BaseDeviceAPI, CommandWithContext } from './device'
 import { Measurement, StateChangeReport } from './measure'
 import { CommandExecutor } from './commandExecutor'
 
-interface StateChange<DeviceState, Command extends CommandWithContext> {
+interface StateChange<DeviceState, Command extends CommandWithContext<any, any>> {
 	commands?: Command[]
 	preliminary?: number
 
@@ -14,14 +14,14 @@ interface StateChange<DeviceState, Command extends CommandWithContext> {
 
 	measurement?: Measurement
 }
-interface ExecutedStateChange<DeviceState, Command extends CommandWithContext>
+interface ExecutedStateChange<DeviceState, Command extends CommandWithContext<any, any>>
 	extends StateChange<DeviceState | undefined, Command> {
 	commands: Command[]
 }
 
 const CLOCK_INTERVAL = 20
 
-export class StateHandler<DeviceState, Command extends CommandWithContext> {
+export class StateHandler<DeviceState, Command extends CommandWithContext<any, any>> {
 	private stateQueue: StateChange<DeviceState, Command>[] = []
 	private currentState: ExecutedStateChange<DeviceState, Command> | undefined
 	/** Semaphore, to ensure that .executeNextStateChange() is only executed one at a time */


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of Superfly


## Type of Contribution

This is a: Code improvement 


## New Behavior

This makes a small improvement to type safety within the device integrations. Each device is using `CommandWithContext` and is expected to extend the type and override the `command` and `context` fields with concrete types.   
Instead, this PR changes this type to be a generic, which forces the connection to define these with a type alias instead.

At various points in the TSR internals this has to be done with `CommandWithContext<any, any>`, where it doesn't matter what the concrete types are. This is typically needed, and matches prior behaviour where the fields were typed as any inside CommandWithContext.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
